### PR TITLE
Clarify the nature of access requests, closes #12

### DIFF
--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -805,7 +805,7 @@ array represent rights of access that the RC is requesting in
 the access token. The requested access is the union of all elements
 within the array.
 
-The RC declares what access it wants to associated with the
+The RC declares what access it wants to associate with the
 resulting access token using objects that describe multiple
 dimensions of access. Each object contains a `type`
 property that determines the type of API that the RC is calling.

--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -802,7 +802,7 @@ sections.
 When requesting an access token, the RC MUST send a
 `resources` field containing a JSON array. The elements of the JSON
 array represent rights of access that the RC is requesting in
-the access token. The requested access is the sum of all elements
+the access token. The requested access is the union of all elements
 within the array.
 
 The RC declares what access it wants to associated with the
@@ -880,14 +880,14 @@ The access requested for a given object when using these fields
 is the cross-product of all fields of the object. That is to 
 say, the object represents a request for all `action` values listed within the object
 to be used at all `locations` values listed within the object for all `datatype`
-values listed within the object. In the example above,
+values listed within the object. Assuming the request above was granted,
 the RC could assume that it
 would be able to do a `read` action against the `images` on the first server
 as well as a `delete` action on the `metadata` of the second server, or any other
-combination of these fields, using the same access token.
+combination of these fields, using the same access token. 
 
 To request a different combination of access, 
-such requesting one `action` against one `location` 
+such as requesting one `action` against one `location` 
 and a different `action` against a different `location`, the 
 RC can include multiple separate objects in the `resources` array.
 The following non-normative example uses the same fictitious `photo-api`
@@ -973,8 +973,8 @@ field. The second access request includes the `actions` and
 ~~~
 
 If this request is approved,
-the [resulting access token](#response-token-single) will include
-the sum of both of the requested types of access for both APIs, just as above.
+the [resulting access token](#response-token-single)'s access rights will be
+the union the requested types of access for each of the two APIs, just as above.
 
 ### Requesting Resources By Reference {#request-resource-reference}
 
@@ -1044,7 +1044,7 @@ as well as the reference values of `read`, `dolphin-metadata`, and `some other t
     ]
 ~~~
 
-The requested access is the sum of all elements of the array, including both objects and 
+The requested access is the union of all elements of the array, including both objects and 
 reference strings.
 
 \[\[ [See issue #36](https://github.com/ietf-wg-gnap/gnap-core-protocol/issues/36) \]\]

--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -851,8 +851,8 @@ identifier (string)
     For example, a patient identifier for a medical API or
     a bank account number for a financial API.
 
-The following non-normative example is asking for two kinds of access to each of
-two different locations and two different data types for a single access token 
+The following non-normative example is asking for three kinds of access (read, write, delete) to each of
+two different locations and two different data types (metadata, images) for a single access token 
 using the fictitious `photo-api` type definition.
 
 ~~~
@@ -861,7 +861,8 @@ using the fictitious `photo-api` type definition.
             "type": "photo-api",
             "actions": [
                 "read",
-                "write"
+                "write",
+                "delete"
             ],
             "locations": [
                 "https://server.example.net/",
@@ -880,8 +881,10 @@ is the cross-product of all fields of the object. That is to
 say, the object represents a request for all `action` values listed within the object
 to be used at all `locations` values listed within the object for all `datatype`
 values listed within the object. In the example above,
-the RC is requesting both `read` and `write` access to two RS locations for
-both `metadata` and `images` within the API.
+the RC could assume that it
+would be able to do a `read` action against the `images` on the first server
+as well as a `delete` action on the `metadata` of the second server, or any other
+combination of these fields, using the same access token.
 
 To request a different combination of access, 
 such requesting one `action` against one `location` 
@@ -908,7 +911,8 @@ targeted access rights by using two discrete objects within the request.
         {
             "type": "photo-api",
             "actions": [
-                "write"
+                "write",
+                "delete"
             ],
             "locations": [
                 "https://resource.local/other"
@@ -921,15 +925,20 @@ targeted access rights by using two discrete objects within the request.
 ~~~
 
 The access requested here is for `read` access to `images` on one server
-while simultaneously requesting `write` access for `metadata` on a different
-server, but importantly without requesting `write` access to `images` on the
+while simultaneously requesting `write` and `delete` access for `metadata` on a different
+server, but importantly without requesting `write` or `delete` access to `images` on the
 first server.
 
 It is anticipated that API designers will use a combination
 of common fields defined in this specification as well as
 fields specific to the API itself. The following non-normative 
 example shows the use of both common and API-specific fields as 
-part of two different access `type` values. 
+part of two different fictitious API `type` values. The first
+access request includes the `actions`, `locations`, and `datatypes` 
+fields specified here as well as the API-specific `geolocation`
+field. The second access request includes the `actions` and
+`identifier` fields specified here as well as the API-specific
+`currency` field.
 
 ~~~
     "resources": [
@@ -948,7 +957,7 @@ part of two different access `type` values.
                 "images"
             ],
             "geolocation": [
-                { lat: -32.364, lng: 153.207 }, // north west
+                { lat: -32.364, lng: 153.207 },
                 { lat: -35.364, lng: 158.207 }
             ]
         },
@@ -965,7 +974,7 @@ part of two different access `type` values.
 
 If this request is approved,
 the [resulting access token](#response-token-single) will include
-the sum of both of the requested types of access for both APIs.
+the sum of both of the requested types of access for both APIs, just as above.
 
 ### Requesting Resources By Reference {#request-resource-reference}
 
@@ -990,7 +999,8 @@ characters, and properly escaped string sequences. However, in some
 situations the value is intended to be 
 seen and understood be the RC developer. In such cases, the
 API designer choosing any such human-readable strings SHOULD take steps
-to ensure the string values are not easily confused by a developer
+to ensure the string values are not easily confused by a developer,
+such as by limiting the strings to easily disambiguated characters.
 
 This functionality is similar in practice to OAuth 2's `scope` parameter {{RFC6749}}, where a single string
 represents the set of access rights requested by the RC. As such, the reference
@@ -998,7 +1008,9 @@ string could contain any valid OAuth 2 scope value as in {{example-oauth2}}. Not
 string here is not bound to the same character restrictions as in OAuth 2's `scope` definition.
 
 A single "resources" array MAY include both object-type and
-string-type resource items.
+string-type resource items. In this non-normative example,
+the RC is requesting access to a `photo-api` and `financial-transaction` API type
+as well as the reference values of `read`, `dolphin-metadata`, and `some other thing`.
 
 ~~~
     "resources": [
@@ -1007,7 +1019,7 @@ string-type resource items.
             "actions": [
                 "read",
                 "write",
-                "dolphin"
+                "delete"
             ],
             "locations": [
                 "https://server.example.net/",
@@ -1031,6 +1043,9 @@ string-type resource items.
         "some other thing"
     ]
 ~~~
+
+The requested access is the sum of all elements of the array, including both objects and 
+reference strings.
 
 \[\[ [See issue #36](https://github.com/ietf-wg-gnap/gnap-core-protocol/issues/36) \]\]
 

--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -803,7 +803,7 @@ When requesting an access token, the RC MUST send a
 `resources` field containing a JSON array. The elements of the JSON
 array represent rights of access that the RC is requesting in
 the access token. The requested access is the sum of all elements
-within the array. 
+within the array.
 
 The RC declares what access it wants to associated with the
 resulting access token using objects that describe multiple
@@ -851,9 +851,9 @@ identifier (string)
     For example, a patient identifier for a medical API or
     a bank account number for a financial API.
 
-The following non-normative example shows the use of both common
-and API-specific fields as part of two different access `type` 
-values. 
+The following non-normative example is asking for two kinds of access to each of
+two different locations and two different data types for a single access token 
+using the fictitious `photo-api` type definition.
 
 ~~~
     "resources": [
@@ -861,8 +861,7 @@ values.
             "type": "photo-api",
             "actions": [
                 "read",
-                "write",
-                "dolphin"
+                "write"
             ],
             "locations": [
                 "https://server.example.net/",
@@ -871,6 +870,86 @@ values.
             "datatypes": [
                 "metadata",
                 "images"
+            ]
+        }
+    ]
+~~~
+
+The access requested for a given object when using these fields 
+is the cross-product of all fields of the object. That is to 
+say, the object represents a request for all `action` values listed within the object
+to be used at all `locations` values listed within the object for all `datatype`
+values listed within the object. In the example above,
+the RC is requesting both `read` and `write` access to two RS locations for
+both `metadata` and `images` within the API.
+
+To request a different combination of access, 
+such requesting one `action` against one `location` 
+and a different `action` against a different `location`, the 
+RC can include multiple separate objects in the `resources` array.
+The following non-normative example uses the same fictitious `photo-api`
+type definition to request a single access token with more specifically
+targeted access rights by using two discrete objects within the request.
+
+~~~
+    "resources": [
+        {
+            "type": "photo-api",
+            "actions": [
+                "read"
+            ],
+            "locations": [
+                "https://server.example.net/"
+            ],
+            "datatypes": [
+                "images"
+            ]
+        },
+        {
+            "type": "photo-api",
+            "actions": [
+                "write"
+            ],
+            "locations": [
+                "https://resource.local/other"
+            ],
+            "datatypes": [
+                "metadata"
+            ]
+        }
+    ]
+~~~
+
+The access requested here is for `read` access to `images` on one server
+while simultaneously requesting `write` access for `metadata` on a different
+server, but importantly without requesting `write` access to `images` on the
+first server.
+
+It is anticipated that API designers will use a combination
+of common fields defined in this specification as well as
+fields specific to the API itself. The following non-normative 
+example shows the use of both common and API-specific fields as 
+part of two different access `type` values. 
+
+~~~
+    "resources": [
+        {
+            "type": "photo-api",
+            "actions": [
+                "read",
+                "write"
+            ],
+            "locations": [
+                "https://server.example.net/",
+                "https://resource.local/other"
+            ],
+            "datatypes": [
+                "metadata",
+                "images"
+            ],
+            "geolocation": [
+                { lat: -32.364, lng: 153.207 }, // north west
+                { lat: -35.364, lng: 158.207 }
             ]
         },
         {
@@ -886,7 +965,7 @@ values.
 
 If this request is approved,
 the [resulting access token](#response-token-single) will include
-the sum of both of the requested types of access.
+the sum of both of the requested types of access for both APIs.
 
 ### Requesting Resources By Reference {#request-resource-reference}
 

--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -974,7 +974,7 @@ field. The second access request includes the `actions` and
 
 If this request is approved,
 the [resulting access token](#response-token-single)'s access rights will be
-the union the requested types of access for each of the two APIs, just as above.
+the union of the requested types of access for each of the two APIs, just as above.
 
 ### Requesting Resources By Reference {#request-resource-reference}
 


### PR DESCRIPTION
This added text clarifies the intent of an object within the `resources` request array, and the nature of combining multiple objects. Added examples should help explain the intended usage.

@yaronf please review to see if this addresses the concern you raise in #12 