### PR TITLE
Replace 'MUST ... if possible' with SHOULD.

### DIFF
--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -3122,7 +3122,7 @@ Detached-JWS: ejy0...
 ~~~
 
 If the request is successfully cancelled, the AS responds with an HTTP 202.
-The AS MUST revoke all associated access tokens, if possible.
+The AS SHOULD revoke all associated access tokens.
 
 # Token Management {#token-management}
 


### PR DESCRIPTION
I don't know much about the GNAP revocation plan, but it seems like having text specifying 'MUST <task> if possible' is the same as SHOULD, per RFC 2119. Maybe I'm missing something :) 

I read the contributing doc, but if PRs as contributions aren't acceptable, please let me know.