### PR TITLE
add verify pr label test

### DIFF
--- a/.github/workflows/verify-pr-labels.yml
+++ b/.github/workflows/verify-pr-labels.yml
@@ -1,0 +1,13 @@
+name: Pull Request Labels
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mheap/github-action-required-labels@v1
+        with:
+          mode: exactly
+          count: 1
+          labels: "Pending Merge, Editorial"


### PR DESCRIPTION
requires "Pending Merge" or "Editorial" labels on a PR before being able to be merged