### PR TITLE
fix small bug about sub_ids in grant response

### DIFF
--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -2278,7 +2278,7 @@ information in the "subject" response field. This field is an object
 with the following OPTIONAL properties.
 
 
-sub_ids (array of strings)
+sub_ids (array of objects)
 : An array of subject identifiers for the
             RO, as defined by 
             {{I-D.ietf-secevent-subject-identifiers}}.


### PR DESCRIPTION
Should be a bug in `3.4. Returning User Information`.
Please take a look. Thank you!