### PR TITLE
update terminology

### DIFF
--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -125,17 +125,17 @@ Roles are defined by the actions taken and the expectations leveraged
 on the role by the overall protocol. 
 
 Authorization Server (AS)
-: server that grants privileges to a particular end-user and that provides them to a client in the form of an access token. 
+: server that grants delegated privileges to a particular instance of client software in the form of an access token and other information (such as subject information). 
 
 Client
 : application operated by an end-user that consumes resources from one or several RSs, possibly requiring access privileges from one or several ASs. 
 
-    Note: this specification differentiates between a specific instance (the Client instance, identified by its public key) and the software running the instance (the Client software). For some kinds of Client software, there could be many instances of a single piece of Client software.
+    Example: a client can be a mobile application, a web application, etc.
 
-    Example: a Client can be a mobile application, a web application, etc.
+    Note: this specification differentiates between a specific instance (the client instance, identified by its unique key) and the software running the instance (the client software). For some kinds of client software, there could be many instances of that software, each instance with a different key.
 
 Resource Server (RS)
-: server that provides operations on resources where protected operations require that the client provides one or more valid access tokens issued by one or more ASs.
+: server that provides operations on protected resources, where operations require a valid access token issued by an AS. 
 
 Resource Owner (RO)
 : subject entity that may grant or deny operations on resources it has authority upon.
@@ -143,7 +143,7 @@ Resource Owner (RO)
     Note: the act of granting or denying an operation may be manual (i.e. through an interaction with a physical person) or automatic (i.e. through predefined organizational rules).
 
 End-user 
-: natural person that operates with the client software.
+: natural person that operates the client instance.
 
     Note: that natural person may or may not be the same entity as the RO. When it is explicit that the end-user and the RO are the same entity, the generic term user may be used. 
 
@@ -195,36 +195,34 @@ In addition to the roles above, the protocol also involves several
 elements that are acted upon by the roles throughout the process.
 
 Attribute
-: characteristics related to an end-user.
+: characteristics related to a subject.
 
 Access Token
-: digitally signed data that contains specific rights and/or attributes.
+: a data artifact representing a set of rights and/or attributes.
 
-    Note: an access token can be first issued to an end-user (usually requiring his authentication) and subsequently refreshed.
-
-Claim
-: statement about a subject.
+    Note: an access token can be first issued to an client instance (requiring authorization by the RO) and subsequently rotated.
 
 Grant
-: (verb): to permit an end-user to exercise some rights and/or to assert some attributes at a specific time and during a specific duration. (noun): the act of granting.
+: (verb): to permit an instance of client software to exercise some set of delegated rights to access a protected resource and/or to receive some attributes at a specific time and during a specific duration. (noun): the act of granting.
 
 Privilege
-: right or attribute associated with an end-user.
+: right or attribute associated with a subject.
 
-Resource
-: public or protected resource from a RS.
+    Note: the RO defines and maintains the rights and attributes associated to the protected resource, and might temporarily delegate some set of those privileges to an end-user. This process is refered to as privilege delegation. 
 
 Protected Resource
 : protected API (Application Programming Interface) served by a RS and that can be accessed by a client, if and only if a valid access token is provided.
 
-Right
-: ability given to an end-user to perform a given operation on a resource under the control of a RS.
+    Note: to avoid complex sentences, the specification document may simply refer to resource instead of protected resource.   
 
-Subject Entity
+Right
+: ability given to a subject to perform a given operation on a resource under the control of a RS.
+
+Subject
 : person, organization or device.
 
 Subject Information
-: claim asserted locally by an AS about a subject entity.
+: statement asserted locally by an AS about a subject.
 
 ## Sequences {#sequence}
 
@@ -283,10 +281,10 @@ protocol flow.
     ~ ~ ~ indicates a potential equivalence or out-of-band communication between roles
 ~~~
 
-- (A) The End-user interacts with the client instance to indicate a need for resources on
+- (A) The end-user interacts with the client instance to indicate a need for resources on
     behalf of the RO. This could identify the RS the client instance needs to call,
     the resources needed, or the RO that is needed to approve the 
-    request. Note that the RO and End-user are often
+    request. Note that the RO and end-user are often
     the same entity in practice.
     
 - (1) The client instance [attempts to call the RS](#rs-request-without-token) to determine 
@@ -306,7 +304,7 @@ protocol flow.
     using a variety of possible mechanisms including web page
     redirects, applications, challenge/response protocols, or 
     other methods. The RO approves the request for the client instance
-    being operated by the End-user. Note that the RO and end-user are often
+    being operated by the end-user. Note that the RO and end-user are often
     the same entity in practice.
 
 - (4) The client instance [continues the grant at the AS](#continue-request).

--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -96,7 +96,7 @@ from the design team regarding the options as understood.
 This protocol allows a piece of software, the client instance, to request delegated
 authorization to resource servers and to request direct information. This delegation is
 facilitated by an authorization server usually on
-behalf of a resource owner. The requesting party operating the software may interact
+behalf of a resource owner. The end-user operating the software may interact
 with the authorization server to authenticate, provide consent, and
 authorize the request.
 
@@ -125,37 +125,27 @@ Roles are defined by the actions taken and the expectations leveraged
 on the role by the overall protocol. 
 
 Authorization Server (AS)
-: Manages the requested delegations for the RO. 
-    The AS issues tokens and directly delegated information to an instance of the client.
-    The AS is defined by its grant endpoint, a single URL that accepts a POST
-    request with a JSON payload. The AS could also have other endpoints,
-    including interaction endpoints and user code endpoints, and these are
-    introduced to the RC as needed during the delegation process. 
+: server that grants privileges to a particular end-user and that provides them to a client in the form of an access token. 
 
 Client
-: Requests tokens and directly delegated information from the AS, and uses tokens at the RS.
-    For some kinds of client software, there could be many instances
-    of a single piece of client software. This specification
-    differentiates between a specific instance (the client instance) and the 
-    software running the instance (the client software).
-    A client instance is identified by its unique key, which can
-    be known to the AS prior to the first request or introduced
-    to the AS as part of the protocol. The AS determines
-    which policies apply to a given client instance, including what it can
-    request and on whose behalf. 
+: application operated by an end-user that consumes resources from one or several RSs, possibly requiring access privileges from one or several ASs. 
 
-Resource Server (RS, aka "API")
-: Accepts tokens from the client instance issued by the AS and serves delegated resources
-    on behalf of the RO. There could be multiple RSs protected
-    by the AS that the client instance will call.
+    Note: this specification differentiates between a specific instance (the Client instance, identified by its public key) and the software running the instance (the Client software). For some kinds of Client software, there could be many instances of a single piece of Client software.
+
+    Example: a Client can be a mobile application, a web application, etc.
+
+Resource Server (RS)
+: server that provides operations on resources where protected operations require that the client provides one or more valid access tokens issued by one or more ASs.
 
 Resource Owner (RO)
-: Authorizes the request from the client instance to the
-    RS, often interactively at the AS.
+: subject entity that may grant or deny operations on resources it has authority upon.
 
-Requesting Party (RQ, aka "user")
-: Operates and interacts with the client instance.
+    Note: the act of granting or denying an operation may be manual (i.e. through an interaction with a physical person) or automatic (i.e. through predefined organizational rules).
 
+End-user 
+: natural person that operates with the client software.
+
+    Note: that natural person may or may not be the same entity as the RO. When it is explicit that the end-user and the RO are the same entity, the generic term user may be used. 
 
 The design of GNAP does not assume any one deployment architecture,
 but instead attempts to define roles that can be fulfilled in a number
@@ -165,9 +155,9 @@ not make additional requirements on its structure or setup.
 
 Multiple roles can be fulfilled by the same party, and a given party
 can switch roles in different instances of the protocol. For example,
-the RO and RQ in many instances are the same person, where a user is
+the RO and end-user in many instances are the same person, where a user is
 authorizing the client instance to act on their own behalf at the RS. In this case,
-one party fulfills both of the RO and RQ roles, but the roles themselves
+one party fulfills both of the RO and end-user roles, but the roles themselves
 are still defined separately from each other to allow for other
 use cases where they are fulfilled by different parties.
 
@@ -179,7 +169,7 @@ RS and a client instance from different perspectives, and it fulfills these
 roles separately as far as the overall protocol is concerned.
 
 A single role need not be deployed as a monolithic service. For example, 
-A client instance could have components that are installed on the RQ's device as 
+A client instance could have components that are installed on the end-user's device as 
 well as a back-end system that it communicates with. If both of these
 components participate in the delegation protocol, they are both considered
 part of the client instance. If there are several copies of the client software
@@ -204,29 +194,37 @@ role of the AS as defined by the protocol.
 In addition to the roles above, the protocol also involves several 
 elements that are acted upon by the roles throughout the process.
 
+Attribute
+: characteristics related to an end-user.
+
 Access Token
-: A credential representing a set of access rights
-delegated to the client instance. The access token is created by the AS, consumed
-and verified by the RS, and issued to and carried by the client instance. The contents
-and format of the access token are opaque to the client.
+: digitally signed data that contains specific rights and/or attributes.
+
+    Note: an access token can be first issued to an end-user (usually requiring his authentication) and subsequently refreshed.
+
+Claim
+: statement about a subject.
 
 Grant
-: The process by which the client instance requests and is given delegated
-access to the RS by the AS through the authority of the RO.
+: (verb): to permit an end-user to exercise some rights and/or to assert some attributes at a specific time and during a specific duration. (noun): the act of granting.
 
-Cryptographic Key
-: A cryptographic element binding a request to a
-holder of the key. Access tokens and client instances can be associated with
-specific keys.
+Privilege
+: right or attribute associated with an end-user.
 
 Resource
-: A protected API served by the RS and accessed by the client instance. Access to this
-resource is delegated by the RO as part of the grant process.
+: public or protected resource from a RS.
+
+Protected Resource
+: protected API (Application Programming Interface) served by a RS and that can be accessed by a client, if and only if a valid access token is provided.
+
+Right
+: ability given to an end-user to perform a given operation on a resource under the control of a RS.
+
+Subject Entity
+: person, organization or device.
 
 Subject Information
-: Information about the RO that is returned directly to the client instance from the AS
-without the client instance making a separate call to an RS. Access to this information
-is delegated by the RO as part of the grant process.
+: claim asserted locally by an AS about a subject entity.
 
 ## Sequences {#sequence}
 
@@ -251,8 +249,8 @@ protocol flow.
 
 ~~~
         +------------+             +------------+
-        | Requesting | ~ ~ ~ ~ ~ ~ |  Resource  |
-        | Party (RQ) |             | Owner (RO) |
+        | End-user   | ~ ~ ~ ~ ~ ~ |  Resource  |
+        |            |             | Owner (RO) |
         +------------+             +------------+
             +                            +      
             +                            +      
@@ -285,10 +283,10 @@ protocol flow.
     ~ ~ ~ indicates a potential equivalence or out-of-band communication between roles
 ~~~
 
-- (A) The RQ interacts with the client instance to indicate a need for resources on
+- (A) The End-user interacts with the client instance to indicate a need for resources on
     behalf of the RO. This could identify the RS the client instance needs to call,
     the resources needed, or the RO that is needed to approve the 
-    request. Note that the RO and RQ are often
+    request. Note that the RO and End-user are often
     the same entity in practice.
     
 - (1) The client instance [attempts to call the RS](#rs-request-without-token) to determine 
@@ -308,7 +306,7 @@ protocol flow.
     using a variety of possible mechanisms including web page
     redirects, applications, challenge/response protocols, or 
     other methods. The RO approves the request for the client instance
-    being operated by the RQ. Note that the RO and RQ are often
+    being operated by the End-user. Note that the RO and end-user are often
     the same entity in practice.
 
 - (4) The client instance [continues the grant at the AS](#continue-request).
@@ -348,7 +346,7 @@ GNAP in different situations and deployments.
 ### Redirect-based Interaction {#sequence-redirect}
 
 In this example flow, the client instance is a web application that wants access to resources on behalf
-of the current user, who acts as both the requesting party (RQ) and the resource
+of the current user, who acts as both the end-user and the resource
 owner (RO). Since the client instance is capable of directing the user to an arbitrary URL and 
 receiving responses from the user's browser, interaction here is handled through
 front-channel redirects using the user's browser. The client instance uses a persistent session
@@ -357,10 +355,10 @@ that returns from the interaction.
 
 ~~~
     +--------+                                  +--------+         +------+
-    | Client |                                  |   AS   |         |  RO  |
-    |Instance|                                  |        |         |  +   |
-    |        |< (1) + Start Session + + + + + + + + + + + + + + + +|  RQ  |
-    |        |                                  |        |         |(User)|
+    | Client |                                  |   AS   |         | User |
+    |Instance|                                  |        |         |      |
+    |        |< (1) + Start Session + + + + + + + + + + + + + + + +|      |
+    |        |                                  |        |         |      |
     |        |--(2)--- Request Access --------->|        |         |      |
     |        |                                  |        |         |      |
     |        |<-(3)-- Interaction Needed -------|        |         |      |
@@ -382,7 +380,7 @@ that returns from the interaction.
     +--------+                                  +--------+
 ~~~
 
-1. The client instance establishes a verifiable session to the user, in the role of the RQ. 
+1. The client instance establishes a verifiable session to the user, in the role of the end-user. 
 
 2. The client instance [requests access to the resource](#request). The client instance indicates that
     it can [redirect to an arbitrary URL](#request-interact-redirect) and
@@ -417,7 +415,7 @@ that returns from the interaction.
     based on this information and continues only if the hash validates.
     Note that the client instance needs to ensure that the parameters for the incoming
     request match those that it is expecting from the session created
-    in (1). The client instance also needs to be prepared for the RQ never being returned
+    in (1). The client instance also needs to be prepared for the end-user never being returned
     to the client instance and handle time outs appropriately.
     
 8. The client instance loads the continuation information from (3) and sends the 
@@ -440,16 +438,16 @@ a known URL. The client instance is not capable of presenting an arbitrary URL t
 nor is it capable of accepting incoming HTTP requests from the user's browser.
 The client instance polls the AS while it is waiting for the RO to authorize the request.
 The user's interaction is assumed to occur on a secondary device. In this example
-it is assumed that the user is both the RQ and RO, though the user is not assumed
+it is assumed that the user is both the end-user and RO, though the user is not assumed
 to be interacting with the client instance through the same web browser used for interaction at
 the AS.
 
 ~~~
     +--------+                                  +--------+         +------+
-    | Client |                                  |   AS   |         |  RO  |
-    |Instance|--(1)--- Request Access --------->|        |         |  +   |
-    |        |                                  |        |         |  RQ  |
-    |        |<-(2)-- Interaction Needed -------|        |         |(User)|
+    | Client |                                  |   AS   |         | User |
+    |Instance|--(1)--- Request Access --------->|        |         |      |
+    |        |                                  |        |         |      |
+    |        |<-(2)-- Interaction Needed -------|        |         |      |
     |        |                                  |        |         |      |
     |        |+ (3) + + Display User Code + + + + + + + + + + + + >|      |
     |        |                                  |        |         |      |
@@ -495,7 +493,7 @@ the AS.
     with the AS through a secondary device, the client instance does not provide a mechanism to
     launch the RO's browser at this URL.
     
-5. The RQ authenticates at the AS, taking on the role of the RO.
+5. The end-user authenticates at the AS, taking on the role of the RO.
 
 6.  The RO enters the code communicated in (3) to the AS. The AS validates this code
     against a current request in process.
@@ -530,7 +528,7 @@ An example set of protocol messages for this method can be found in {{example-de
 
 ### Asynchronous Authorization {#sequence-async}
 
-In this example flow, the RQ and RO roles are fulfilled by different parties, and
+In this example flow, the end-user and RO roles are fulfilled by different parties, and
 the RO does not interact with the client instance. The AS reaches out asynchronously to the RO 
 during the request process to gather the RO's authorization for the client instance's request. 
 The client instance polls the AS while it is waiting for the RO to authorize the request.
@@ -702,8 +700,8 @@ client (object / string)
     interactions at the AS. {{request-client}}
 
 user (object / string)
-: Identifies the RQ to the AS in a manner that the AS can verify, either directly or
-    by interacting with the RQ to determine their status as the RO. {{request-user}}
+: Identifies the end-user to the AS in a manner that the AS can verify, either directly or
+    by interacting with the end-user to determine their status as the RO. {{request-user}}
 
 interact (object)
 : Describes the modes that the client instance has for allowing the RO to interact with the
@@ -1429,14 +1427,14 @@ client instances with unknown keys have to be interactively approved by an RO.
 
 ## Identifying the User {#request-user}
 
-If the client instance knows the identity of the RQ through one or more
+If the client instance knows the identity of the end-user through one or more
 identifiers or assertions, the client instance MAY send that information to the
 AS in the "user" field. The client instance MAY pass this information by value
 or by reference.
 
 sub_ids (array of strings)
 : An array of subject identifiers for the
-            RQ, as defined by {{I-D.ietf-secevent-subject-identifiers}}.
+            end-user, as defined by {{I-D.ietf-secevent-subject-identifiers}}.
 
 assertions (object)
 : An object containing assertions as values keyed on the assertion 
@@ -1461,11 +1459,10 @@ assertions (object)
 
 Subject identifiers are hints to the AS in determining the
 RO and MUST NOT be taken as declarative statements that a particular
-RO is present at the client instance and acting as the RQ. Assertions SHOULD be validated by the
-AS. 
+RO is present at the client instance and acting as the end-user. Assertions SHOULD be validated by the AS. 
 \[\[ [See issue #49](https://github.com/ietf-wg-gnap/gnap-core-protocol/issues/49) \]\]
 
-If the identified RQ does not match the RO present at the AS
+If the identified end-user does not match the RO present at the AS
 during an interaction step, the AS SHOULD reject the request with an error.
 
 \[\[ [See issue #50](https://github.com/ietf-wg-gnap/gnap-core-protocol/issues/50) \]\]
@@ -1479,9 +1476,9 @@ if the client instance provides one or more interaction modes in its request.
 
 User reference identifiers can be dynamically
 [issued by the AS](#response-dynamic-handles) to allow the client instance 
-to represent the same RQ to the AS over subsequent requests.
+to represent the same end-user to the AS over subsequent requests.
 
-If the client instance has a reference for the RQ at this AS, the
+If the client instance has a reference for the end-user at this AS, the
 client instance MAY pass that reference as a string. The format of this string
 is opaque to the client instance.
 
@@ -1502,9 +1499,9 @@ return an error.
 
 Many times, the AS will require interaction with the RO in order to
 approve a requested delegation to the client instance for both resources and direct
-claim information. Many times the RQ using the client instance is the same person as
+claim information. Many times the end-user using the client instance is the same person as
 the RO, and the client instance can directly drive interaction with the AS by redirecting
-the RQ on the same device, or by launching an application. Other times, the 
+the end-user on the same device, or by launching an application. Other times, the 
 client instance can provide information to start the RO's interaction on a secondary
 device, or the client instance will wait for the RO to approve the request asynchronously.
 The client instance could also be signaled that interaction has completed by the AS making
@@ -1521,11 +1518,11 @@ its capabilities and what is allowed to fulfill the request. This specification
 defines the following interaction modes:
 
 redirect (boolean)
-: Indicates that the client instance can direct the RQ to an arbitrary URL
+: Indicates that the client instance can direct the end-user to an arbitrary URL
     at the AS for interaction. {{request-interact-redirect}}
 
 app (boolean)
-: Indicates that the client instance can launch an application on the RQ's
+: Indicates that the client instance can launch an application on the end-user's
     device for interaction. {{request-interact-app}}
 
 callback (object)
@@ -1534,10 +1531,10 @@ callback (object)
 
 user_code (boolean)
 : Indicates that the client instance can communicate a human-readable short
-    code to the RQ for use with a stable URL at the AS. {{request-interact-usercode}}
+    code to the end-user for use with a stable URL at the AS. {{request-interact-usercode}}
 
 ui_locales (array of strings)
-: Indicates the RQ's preferred locales that the AS can use
+: Indicates the end-user's preferred locales that the AS can use
     during interaction, particularly before the RO has 
     authenticated. {{request-interact-locale}}
 
@@ -1546,7 +1543,7 @@ modes. Additional interaction modes are defined in
 [a registry TBD](#IANA).
 
 In this non-normative example, the client instance is indicating that it can [redirect](#request-interact-redirect)
-the RQ to an arbitrary URL and can receive a [callback](#request-interact-callback) through
+the end-user to an arbitrary URL and can receive a [callback](#request-interact-callback) through
 a browser request.
 
 ~~~
@@ -1561,7 +1558,7 @@ a browser request.
 ~~~
 
 In this non-normative example, the client instance is indicating that it can 
-display a [user code](#request-interact-usercode) and direct the RQ
+display a [user code](#request-interact-usercode) and direct the end-user
 to an [arbitrary URL](#request-interact-redirect) on a secondary
 device, but it cannot accept a callback.
 
@@ -1584,12 +1581,12 @@ apply suitable timeouts to any callback URLs.
 
 ### Redirect to an Arbitrary URL {#request-interact-redirect}
 
-If the client instance is capable of directing the RQ to a URL defined
+If the client instance is capable of directing the end-user to a URL defined
 by the AS at runtime, the client instance indicates this by sending the
 "redirect" field with the boolean value "true". The means by which
 the client instance will activate this URL is out of scope of this
 specification, but common methods include an HTTP redirect,
-launching a browser on the RQ's device, providing a scannable
+launching a browser on the end-user's device, providing a scannable
 image encoding, and printing out a URL to an interactive
 console.
 
@@ -1605,7 +1602,7 @@ request, the AS returns a redirect interaction response {{response-interact-redi
 ### Open an Application-specific URL {#request-interact-app}
 
 If the client instance can open a URL associated with an application on
-the RQ's device, the client instance indicates this by sending the "app"
+the end-user's device, the client instance indicates this by sending the "app"
 field with boolean value "true". The means by which the client instance
 determines the application to open with this URL are out of scope of
 this specification.
@@ -1709,8 +1706,8 @@ Requests to the callback URI MUST be processed by the client instance as describ
 {{interaction-callback}}.
 
 Since the incoming request to the callback URL is from the RO's
-browser, this method is usually used when the RO and RQ are the
-same entity. As such, the client instance MUST ensure the RQ is present on the request to
+browser, this method is usually used when the RO and end-user are the
+same entity. As such, the client instance MUST ensure the end-user is present on the request to
 prevent substitution attacks.
 
 #### Receive an HTTP Direct Callback {#request-interact-callback-push}
@@ -1733,7 +1730,7 @@ Requests to the callback URI MUST be processed by the client instance as describ
 {{interaction-pushback}}.
 
 Since the incoming request to the callback URL is from the AS and
-not from the RO's browser, the client instance MUST NOT require the RQ to
+not from the RO's browser, the client instance MUST NOT require the end-user to
 be present on the incoming HTTP request.
 
 \[\[ [See issue #60](https://github.com/ietf-wg-gnap/gnap-core-protocol/issues/60) \]\]
@@ -1758,7 +1755,7 @@ in {{interaction-usercode}}.
 
 ### Indicate Desired Interaction Locales {#request-interact-locale}
 
-If the client instance knows the RQ's locale and language preferences, the
+If the client instance knows the end-user's locale and language preferences, the
 client instance can send this information to the AS using the `ui_locales` field
 with an array of locale strings as defined by {{RFC5646}}.
 
@@ -1841,7 +1838,7 @@ instance_id (string)
     future requests. {{response-dynamic-handles}}
 
 user_handle (string)
-: An identifier this client instance instance can use to identify its current RQ when
+: An identifier this client instance instance can use to identify its current end-user when
     making future requests. {{response-dynamic-handles}}
 
 error (object)
@@ -2130,7 +2127,7 @@ particularly if the client instance [modifies its request](#continue-modify).
 
 If the client instance indicates that it can [redirect to an arbitrary URL](#request-interact-redirect) and the AS supports this mode for the client instance's
 request, the AS responds with the "redirect" field, which is
-a string containing the URL to direct the RQ to. This URL MUST be
+a string containing the URL to direct the end-user to. This URL MUST be
 unique for the request and MUST NOT contain any security-sensitive
 information.
 
@@ -2147,9 +2144,9 @@ functionality.
 
 \[\[ [See issue #72](https://github.com/ietf-wg-gnap/gnap-core-protocol/issues/72) \]\]
 
-The client instance sends the RQ to the URL to interact with the AS. The
+The client instance sends the end-user to the URL to interact with the AS. The
 client instance MUST NOT alter the URL in any way. The means for the client instance
-to send the RQ to this URL is out of scope of this specification,
+to send the end-user to this URL is out of scope of this specification,
 but common methods include an HTTP redirect, launching the system
 browser, displaying a scannable code, or printing out the URL in an
 interactive console.
@@ -2159,7 +2156,7 @@ interactive console.
 If the client instance indicates that it can [launch an application URL](#request-interact-app) and
 the AS supports this mode for the client instance's request, the AS
 responds with the "app" field, which is a string containing the URL
-to direct the RQ to. This URL MUST be unique for the request and
+to direct the end-user to. This URL MUST be unique for the request and
 MUST NOT contain any security-sensitive information.
 
 ~~~
@@ -2233,7 +2230,7 @@ url (string)
     }
 ~~~
 
-The client instance MUST communicate the "code" to the RQ in some
+The client instance MUST communicate the "code" to the end-user in some
 fashion, such as displaying it on a screen or reading it out
 audibly. The `code` is a one-time-use credential that the AS uses to identify
 the pending request from the client instance. When the RO [enters this code](#interaction-usercode) into the
@@ -2247,11 +2244,11 @@ to facilitate user interaction, but since the URL should be stable,
 the client instance should be able to safely decide to not display this value.
 As this interaction mode is designed to facilitate interaction
 via a secondary device, it is not expected that the client instance redirect
-the RQ to the URL given here at runtime. Consequently, the URL needs to 
+the end-user to the URL given here at runtime. Consequently, the URL needs to 
 be stable enough that a client instance could be statically configured with it, perhaps
-referring the RQ to the URL via documentation instead of through an
+referring the end-user to the URL via documentation instead of through an
 interactive means. If the client instance is capable of communicating an
-arbitrary URL to the RQ, such as through a scannable code, the
+arbitrary URL to the end-user, such as through a scannable code, the
 client instance can use the ["redirect"](#request-interact-redirect) mode
 for this purpose instead of or in addition to the user code mode.
 
@@ -2309,7 +2306,7 @@ updated_at (string)
 ~~~
 
 The AS MUST return the `subject` field only in cases where the AS is sure that
-the RO and the RQ are the same party. This can be accomplished through some forms of
+the RO and the end-user are the same party. This can be accomplished through some forms of
 [interaction with the RO](#user-interaction).
 
 Subject identifiers returned by the AS SHOULD uniquely identify the RO at the
@@ -2440,7 +2437,7 @@ initiate one of the returned
 When the RO is interacting with the AS, the AS MAY perform whatever
 actions it sees fit, including but not limited to:
 
-- authenticate the current user (who may be the RQ) as the RO
+- authenticate the current user (who may be the end-user) as the RO
 
 - gather consent and authorization from the RO for access to
           requested resources and direct information
@@ -2468,8 +2465,8 @@ note that the RO MAY open the URL on a separate device from the client instance
 itself. The interaction URL MUST be accessible from an HTTP GET
 request, and MUST be protected by HTTPS or equivalent means.
 
-With this method, it is common for the RO to be the same party as the RQ, since
-the client instance has to communicate the redirection URI to the RQ.
+With this method, it is common for the RO to be the same party as the end-user, since
+the client instance has to communicate the redirection URI to the end-user.
 
 ## Interaction at the User Code URI {#interaction-usercode}
 
@@ -2487,9 +2484,9 @@ note that the RO MAY open the URL on a separate device from the client instance
 itself. The user code URL MUST be accessible from an HTTP GET request,
 and MUST be protected by HTTPS or equivalent means.
 
-While it is common for the RO to be the same party as the RQ, since
+While it is common for the RO to be the same party as the end-user, since
 the client instance has to communicate the user code to someone, there are
-cases where the RQ and RO are separate parties and the authorization
+cases where the end-user and RO are separate parties and the authorization
 happens asynchronously.
 
 
@@ -2891,7 +2888,7 @@ replaces any values from a previous request. The AS MAY respond to any of the in
 responses as described in {{response-interact}}, just like it would to a new request.
 
 The client instance MAY include the `user` field as described in {{request-user}} to present new assertions
-or information about the RQ. 
+or information about the end-user. 
 \[\[ [See issue #93](https://github.com/ietf-wg-gnap/gnap-core-protocol/issues/93) \]\]
 
 The client instance MUST NOT include the `client` section of the request.

--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -143,9 +143,9 @@ Resource Owner (RO)
     Note: the act of granting or denying an operation may be manual (i.e. through an interaction with a physical person) or automatic (i.e. through predefined organizational rules).
 
 End-user 
-: natural person that operates the client instance.
+: natural person that operates a client instance.
 
-    Note: that natural person may or may not be the same entity as the RO. When it is explicit that the end-user and the RO are the same entity, the generic term user may be used. 
+    Note: that natural person may or may not be the same entity as the RO. 
 
 The design of GNAP does not assume any one deployment architecture,
 but instead attempts to define roles that can be fulfilled in a number
@@ -203,7 +203,7 @@ Access Token
     Note: an access token can be first issued to an client instance (requiring authorization by the RO) and subsequently rotated.
 
 Grant
-: (verb): to permit an instance of client software to exercise some set of delegated rights to access a protected resource and/or to receive some attributes at a specific time and during a specific duration. (noun): the act of granting.
+: (verb): to receive some attributes at a specific time and valid for a specific duration and/or to permit an instance of client software to exercise some set of delegated rights to access a protected resource (noun): the act of granting.
 
 Privilege
 : right or attribute associated with a subject.

--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -203,7 +203,7 @@ Access Token
     Note: an access token can be first issued to an client instance (requiring authorization by the RO) and subsequently rotated.
 
 Grant
-: (verb): to receive some attributes at a specific time and valid for a specific duration and/or to permit an instance of client software to exercise some set of delegated rights to access a protected resource (noun): the act of granting.
+: (verb): to permit an instance of client software to receive some attributes at a specific time and valid for a specific duration and/or to exercise some set of delegated rights to access a protected resource (noun): the act of granting. (noun): the act of granting.
 
 Privilege
 : right or attribute associated with a subject.

--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -203,7 +203,7 @@ Access Token
     Note: an access token can be first issued to an client instance (requiring authorization by the RO) and subsequently rotated.
 
 Grant
-: (verb): to permit an instance of client software to receive some attributes at a specific time and valid for a specific duration and/or to exercise some set of delegated rights to access a protected resource (noun): the act of granting. (noun): the act of granting.
+: (verb): to permit an instance of client software to receive some attributes at a specific time and valid for a specific duration and/or to exercise some set of delegated rights to access a protected resource (noun): the act of granting. 
 
 Privilege
 : right or attribute associated with a subject.


### PR DESCRIPTION
This corresponds to #29 and the related [wiki](https://github.com/ietf-wg-gnap/gnap-core-protocol/wiki/Terminology), as well as advances on the mailing list. 

Sections 1.2 and 1.3 have been updated accordingly.
The term "cryptographic keys" has been removed. Some additional terms have been added (especially sub-definitions, such as "right", "attribute", "privilege").
The term RQ has been renamed to end-user and changes in the main text.

I kept a simple layout for notes and examples, maybe this can be improved.  