### PR TITLE
Fix the example of Attached JWS

### DIFF
--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -3428,8 +3428,8 @@ This example's JWS header decodes to:
 {
   "alg": "RS256",
   "kid": "KAgNpWbRyy9Mf2rikl498LThMrvkbZWHVSQOBC4VHU4",
-  "htm": "post",
-  "htu": "/tx",
+  "htm": "POST",
+  "htu": "https://server.example.com/tx",
   "ts": 1603800783
 }
 ~~~


### PR DESCRIPTION
Field "htm" should be in uppercase and field "htu" provide the whole HTTP URI.

Provided [JWT](https://jwt.io/#debugger-io?token=eyJhbGciOiJSUzI1NiIsImtpZCI6IktBZ05wV2JSeXk5TWYycmlrbDQ5OExUaE1ydmtiWldIVlNRT0JDNFZIVTQiLCJodG0iOiJwb3N0IiwiaHR1IjoiL3R4IiwidHMiOjE2MDM4MDA3ODN9.ewogICJjYXBhYmlsaXRpZXMiOiBbXSwKICAiY2xpZW50IjogewogICAgImtleSI6IHsKICAgICAgImp3ayI6IHsKICAgICAgICAia3R5IjogIlJTQSIsCiAgICAgICAgImUiOiAiQVFBQiIsCiAgICAgICAgImtpZCI6ICJLQWdOcFdiUnl5OU1mMnJpa2w0OThMVGhNcnZrYlpXSFZTUU9CQzRWSFU0IiwKICAgICAgICAibiI6ICJsbFdtSEY4WEEyS05MZG14T1Aza3hEOU9ZNzZwMFNyMzdqZmh6OTRhOTN4bTJGTnFvU1BjCiAgICAgICAgUlpBUGQwbHFEUzhOM1VpYTUzZEIyM1o1OU93WTRicE1fVmY4R0p2dnB0TFdueG8xUHlobVByLWVjZAogICAgICAgIFNDUlFkVGNfWmNNRjRoUlY0OHFxbHZ1RDBtcXRjRGJJa1NCRHZjY0ptWkh3ZlRwREhpblQ4dHR2Y1YKICAgICAgICBQOFZrQU1BcTRrVmF6eE9wTW9JUnNveUVwX2VDZTVwU3dxSG8wZGFDV05LUi1FcEttNk5pT3RlZEY0CiAgICAgICAgT3VtdDhOTEtUVmpmWWdGSGVCRGRDYnJyRVRkNHZCTXdEdEFualByM0NWQ3d3eDJiQVFUNlNseEZKMwogICAgICAgIGZqMmhoeUlwcTdwYzhyWmliNWpOeVhLd2ZCdWtUVllab3prc2h0LUxvaHlBU2FLcFlUcDhMdE5aLXciCiAgICAgIH0sCiAgICAgICJwcm9vZiI6ICJqd3MiCiAgICB9LAogICAgIm5hbWUiOiAiTXkgRmlzdCBDbGllbnQiLAogICAgInVyaSI6ICJodHRwOi8vbG9jYWxob3N0L2NsaWVudC9jbGllbnRJRCIKICB9LAogICJpbnRlcmFjdCI6IHsKICAgICJjYWxsYmFjayI6IHsKICAgICAgIm1ldGhvZCI6ICJyZWRpcmVjdCIsCiAgICAgICJub25jZSI6ICJkOTAyMTM4ODRiODQwOTIwNTM4YjVjNTEiLAogICAgICAidXJpIjogImh0dHA6Ly9sb2NhbGhvc3QvY2xpZW50L3JlcXVlc3QtZG9uZSIKICAgIH0sCiAgICAicmVkaXJlY3QiOiB0cnVlCiAgfSwKICAiYWNjZXNzX3Rva2VuIjogewogICAgImFjY2VzcyI6IFsKICAgICAgewogICAgICAgICJhY3Rpb25zIjogWwogICAgICAgICAgInJlYWQiLAogICAgICAgICAgInByaW50IgogICAgICAgIF0sCiAgICAgICAgImxvY2F0aW9ucyI6IFsKICAgICAgICAgICJodHRwOi8vbG9jYWxob3N0L3Bob3RvcyIKICAgICAgICBdLAogICAgICAgICJ0eXBlIjogInBob3RvLWFwaSIKICAgICAgfQogICAgXQogIH0KICAic3ViamVjdCI6IHsKICAgICJzdWJfaWRzIjogWwogICAgICAiaXNzX3N1YiIsCiAgICAgICJlbWFpbCIKICAgIF0KICB9Cn0K.LUyZ8_fERmxbYARq8kBYMwzcd8GnCAKAlo2ZSYLRRNAYWPrp2XGLJOvg97WK1idf_LB08OJmLVsCXxCvn9mgaAkYNL_ZjHcusBvY1mNo0E1sdTEr31CVKfC-6WrZCscb8YqE4Ayhh0Te8kzSng3OkLdy7xN4xeKuHzpF7yGsM52JZ0cBcTo6WrYEfGdr08AWQJ59ht72n3jTsmYNy9A6I4Wrvfgj3TNxmwYojpBAicfjnzA1UVcNm9F_xiSz1_y2tdH7j5rVqBMQife-k9Ewk95vr3lurthenliYSNiUinVfoW1ybnaIBcTtP1_YCxg_h1y-B5uZEvYNGCuoCqa6IQ) is incorrect (see its payload). 

Although, it may make sense to not provide the whole JWT for brevity purposes.

