### PR TITLE
Requirements for the location of grant_request_endpoint.

### DIFF
--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -45,6 +45,7 @@ normative:
            ins: P. Saint-Andre
     RFC2119:
     RFC3230:
+    RFC3986:
     RFC5646:
     RFC7468:
     RFC7515:
@@ -4073,9 +4074,11 @@ containing the following information:
 
 
 grant_request_endpoint (string)
-: REQUIRED. The full URL of the
-          AS's grant request endpoint. This MUST match the URL the client instance used to
-          make the discovery request.
+: REQUIRED. The location of the
+          AS's grant request endpoint. The location MUST be a URI (#RFC3986)
+          with a scheme component that MUST be https, a host component, and optionally,
+          port, path and query components and no fragment components. This URL MUST
+          match the URL the client instance used to make the discovery request.
 
 capabilities (array of strings)
 : OPTIONAL. A list of the AS's

--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -4075,7 +4075,7 @@ containing the following information:
 
 grant_request_endpoint (string)
 : REQUIRED. The location of the
-          AS's grant request endpoint. The location MUST be a URI {{RFC3986}}
+          AS's grant request endpoint. The location MUST be a URL {{RFC3986}}
           with a scheme component that MUST be https, a host component, and optionally,
           port, path and query components and no fragment components. This URL MUST
           match the URL the client instance used to make the discovery request.

--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -4075,7 +4075,7 @@ containing the following information:
 
 grant_request_endpoint (string)
 : REQUIRED. The location of the
-          AS's grant request endpoint. The location MUST be a URI (#RFC3986)
+          AS's grant request endpoint. The location MUST be a URI ({{RFC3986}})
           with a scheme component that MUST be https, a host component, and optionally,
           port, path and query components and no fragment components. This URL MUST
           match the URL the client instance used to make the discovery request.

--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -4075,7 +4075,7 @@ containing the following information:
 
 grant_request_endpoint (string)
 : REQUIRED. The location of the
-          AS's grant request endpoint. The location MUST be a URI ({{RFC3986}})
+          AS's grant request endpoint. The location MUST be a URI {{RFC3986}}
           with a scheme component that MUST be https, a host component, and optionally,
           port, path and query components and no fragment components. This URL MUST
           match the URL the client instance used to make the discovery request.


### PR DESCRIPTION
Suggested changes for https://github.com/ietf-wg-gnap/gnap-core-protocol/issues/180

They could be also simplified to something like

> This URL MUST use the HTTPS scheme and MAY contain port, path, and query parameter components. The URL MUST NOT contain fragment components.