### PR TITLE
Adding information about the Cache-Control header and its value.

### DIFF
--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -4146,7 +4146,9 @@ token's presentation, such as its intended proofing mechanism and key
 material.
 
 ~~~
+HTTP/1.1 200 OK
 Content-Type: application/json
+Cache-Control: no-store
 
 {
     "active": true,
@@ -4297,7 +4299,9 @@ The AS responds with a handle appropriate to represent the
 resources list that the RS presented.
 
 ~~~
+HTTP/1.1 200 OK
 Content-Type: application/json
+Cache-Control: no-store
 
 {
     "resource_handle": "FWWIKYBQ6U56NL1"
@@ -4526,7 +4530,9 @@ client instance that it can use the given instance identifier to identify itself
 [future requests](#request-instance).
 
 ~~~
+HTTP/1.1 200 OK
 Content-Type: application/json
+Cache-Control: no-store
 
 {
     "interact": {
@@ -4599,7 +4605,9 @@ The AS retrieves the pending request based on the handle and issues
 a bearer access token and returns this to the client instance.
 
 ~~~
+HTTP/1.1 200 OK
 Content-Type: application/json
+Cache-Control: no-store
 
 {
     "access_token": {
@@ -4674,7 +4682,9 @@ a nonce, but does include a "wait" parameter on the continuation
 section because it expects the client instance to poll for results.
 
 ~~~
+HTTP/1.1 200 OK
 Content-Type: application/json
+Cache-Control: no-store
 
 {
     "interact": {
@@ -4729,7 +4739,9 @@ the client instance that no access token has yet been issued but it can
 continue to call after another 60 second timeout.
 
 ~~~
+HTTP/1.1 200 OK
 Content-Type: application/json
+Cache-Control: no-store
 
 {
     "continue": {
@@ -4762,7 +4774,9 @@ determines that it has been approved, and issues an access
 token for the client to use at the RS.
 
 ~~~
+HTTP/1.1 200 OK
 Content-Type: application/json
+Cache-Control: no-store
 
 {
     "access_token": {
@@ -4811,7 +4825,9 @@ The AS processes this and determines that the client instance can ask for
 the requested resources and issues an access token.
 
 ~~~
+HTTP/1.1 200 OK
 Content-Type: application/json
+Cache-Control: no-store
 
 {
     "access_token": {
@@ -4891,7 +4907,9 @@ request. The AS indicates to the client instance that it can poll for
 continuation.
 
 ~~~
+HTTP/1.1 200 OK
 Content-Type: application/json
+Cache-Control: no-store
 
 {
     "continue": {
@@ -4929,7 +4947,9 @@ the client instance that no access token has yet been issued but it can
 continue to call after another 60 second timeout.
 
 ~~~
+HTTP/1.1 200 OK
 Content-Type: application/json
+Cache-Control: no-store
 
 {
     "continue": {
@@ -4963,7 +4983,9 @@ determines that it has been approved and it issues an access
 token.
 
 ~~~
+HTTP/1.1 200 OK
 Content-Type: application/json
+Cache-Control: no-store
 
 {
     "access_token": {

--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -770,6 +770,10 @@ The request MUST be sent as a JSON object in the body of the HTTP
 POST request with Content-Type `application/json`,
 unless otherwise specified by the signature mechanism.
 
+The authorization server response MUST be a JSON object in the body of the HTTP
+response with Content-Type `application/json`. The authorization server MUST
+include the HTTP "Cache-Control" response header field with a value set to "no-store".
+
 ## Requesting Access to Resources {#request-token}
 
 If the client instance is requesting one or more access tokens for the

--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -766,13 +766,11 @@ A non-normative example of a grant request is below:
 
 
 
-The request MUST be sent as a JSON object in the body of the HTTP
+The request and response MUST be sent as a JSON object in the body of the HTTP
 POST request with Content-Type `application/json`,
 unless otherwise specified by the signature mechanism.
 
-The authorization server response MUST be a JSON object in the body of the HTTP
-response with Content-Type `application/json`. The authorization server MUST
-include the HTTP "Cache-Control" response header field with a value set to "no-store".
+The authorization server MUST include the HTTP "Cache-Control" response header field with a value set to "no-store".
 
 ## Requesting Access to Resources {#request-token}
 

--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -46,6 +46,7 @@ normative:
     RFC2119:
     RFC3230:
     RFC5646:
+    RFC7234:
     RFC7468:
     RFC7515:
     RFC7517:
@@ -770,7 +771,7 @@ The request and response MUST be sent as a JSON object in the body of the HTTP
 POST request with Content-Type `application/json`,
 unless otherwise specified by the signature mechanism.
 
-The authorization server MUST include the HTTP "Cache-Control" response header field with a value set to "no-store".
+The authorization server MUST include the HTTP "Cache-Control" response header field {{RFC7234}} with a value set to "no-store".
 
 ## Requesting Access to Resources {#request-token}
 


### PR DESCRIPTION
The specification doesn't mention the Cache-Control header, as well as the Content-Type header for the responses. This is the 1st step to add this information.

All examples of responses may also include this header. Right now, it's true for a few examples.

I am unsure if it's necessary to include a bit obsolete header Pragma.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Pragma#content:~:text=Use%20Pragma%20only%20for%20backwards%20compatibility%20with%20HTTP%2F1.0%20clients.