### PR TITLE
Syntax and schema based normalization for URI in the htu claim.

### DIFF
--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -45,6 +45,7 @@ normative:
            ins: P. Saint-Andre
     RFC2119:
     RFC3230:
+    RFC3986:
     RFC5646:
     RFC7468:
     RFC7515:
@@ -3269,6 +3270,10 @@ the object is signed according to detached JWS {{RFC7797}}.
 The client instance presents the signature in the Detached-JWS HTTP Header
 field. 
 
+The authorization and resource server SHOULD employ Syntax-Based Normalization and Scheme-Based
+Normalization in accordance with Section 6.2.2. and Section 6.2.3. of
+{{RFC3986}} before comparing the "htu" claim.
+
 ~~~
 POST /tx HTTP/1.1
 Host: server.example.com
@@ -3364,6 +3369,10 @@ The client instance presents the JWS as the body of the request along with a
 content type of `application/jose`. The AS
 MUST extract the payload of the JWS and treat it as the request body
 for further processing.
+
+The authorization and resource server SHOULD employ Syntax-Based Normalization and Scheme-Based
+Normalization in accordance with Section 6.2.2. and Section 6.2.3. of
+{{RFC3986}} before comparing the "htu" claim.
 
 ~~~
 POST /tx HTTP/1.1


### PR DESCRIPTION
This requirement almost one by one copied from https://tools.ietf.org/html/draft-ietf-oauth-dpop-02 as it's a quite important nuance in practical usage.

I suggest also renaming `ts` to `iat` (issued at).

Finally, I think that both attached and detached JWS proving possession mechanisms must include the "typ" header parameter with appropriate values.