### PR TITLE
change subject type to format to comply with secevent draft07

### DIFF
--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -760,7 +760,7 @@ A non-normative example of a grant request is below:
     },
     "capabilities": ["ext1", "ext2"],
     "subject": {
-        "subject_types": ["iss_sub", "email"],
+        "formats": ["iss_sub", "email"],
         "assertions": ["id_token"]
     }
 }
@@ -952,7 +952,7 @@ the AS, it sends a `subject` field as a JSON object. This object MAY
 contain the following fields (or additional fields defined in 
 [a registry TBD](#IANA)).
 
-subject_types (array of strings)
+formats (array of strings)
 : An array of subject identifier subject types
             requested for the RO, as defined by {{I-D.ietf-secevent-subject-identifiers}}.
 
@@ -964,7 +964,7 @@ assertions (array of strings)
 
 ~~~
 "subject": {
-   "subject_types": [ "iss_sub", "email" ],
+   "formats": [ "iss_sub", "email" ],
    "assertions": [ "id_token", "saml2" ]
 }
 ~~~
@@ -983,7 +983,7 @@ The AS SHOULD NOT re-use subject identifiers for multiple different ROs.
 
 \[\[ [See issue #42](https://github.com/ietf-wg-gnap/gnap-core-protocol/issues/42) \]\]
 
-Note: the "subject_types" and "assertions" request fields are independent of
+Note: the "formats" and "assertions" request fields are independent of
 each other, and a returned assertion MAY omit a requested subject
 identifier. 
 
@@ -1183,7 +1183,7 @@ assertions (object)
 ~~~
 "user": {
    "sub_ids": [ {
-     "subject_type": "email",
+     "format": "email",
      "email": "user@example.com"
    } ],
    "assertions": {
@@ -1632,7 +1632,7 @@ an email address.
     },
     "subject": {
         "sub_ids": [ {
-           "subject_type": "email",
+           "format": "email",
            "email": "user@example.com",
         } ]
     }
@@ -2114,7 +2114,7 @@ updated_at (string)
 ~~~
 "subject": {
    "sub_ids": [ {
-     "subject_type": "email",
+     "format": "email",
      "email": "user@example.com",
    } ],
    "assertions": {
@@ -2613,7 +2613,7 @@ release subject claims, the response could look like this:
     },
     "subject": {
         "sub_ids": [ {
-           "subject_type": "email",
+           "format": "email",
            "email": "user@example.com",
         } ]
     }
@@ -2680,7 +2680,7 @@ release subject claims, the response could look like this example:
     },
     "subject": {
         "sub_ids": [ {
-           "subject_type": "email",
+           "format": "email",
            "email": "user@example.com",
         } ]
     }
@@ -3473,7 +3473,7 @@ And the JWS body decodes to:
     ]
   }
   "subject": {
-    "subject_types": ["iss_sub", "email"]
+    "formats": ["iss_sub", "email"]
   }
 }
 ~~~
@@ -4094,7 +4094,7 @@ key_proofs_supported (array of strings)
           values of the `proof` field of the 
           [key section](#key-format) of the request.
 
-subject_types_supported (array of strings)
+subject_formats_supported (array of strings)
 : OPTIONAL. A list of the AS's supported
           subject identifier types. The values of this list correspond to possible values
           of the [subject identifier section](#request-subject) of the request.
@@ -4433,7 +4433,7 @@ sure that it has the permission to do so.
     - Changed "interaction_methods" to "interaction_methods_supported".
     - Changed "key_proofs" to "key_proofs_supported".
     - Changed "assertions" to "assertions_supported".
-    - Updated discovery and field names for subject types.
+    - Updated discovery and field names for subject formats.
 
 - -04
     - Updated terminology.
@@ -4923,7 +4923,7 @@ Detached-JWS: ejy0...
     "client": "7C7C4AZ9KHRS6X63AJAO",
     "user": {
         "sub_ids": [ {
-            "subject_type": "email",
+            "format": "email",
             "email": "user@example.com"
         } ]
    }


### PR DESCRIPTION
align with [draft-07](https://datatracker.ietf.org/doc/html/draft-ietf-secevent-subject-identifiers-07)

I think however this might be a problem when we already use `format` in the text, in many places (token format, key format, assertion format etc.). Ex in section 2.2, we would have formats (relates to subject identifiers) and just below we discuss assertions: "assertions (array of strings)  An array of requested assertion formats." Of course we could change when there's potential confusion, but it shows it's not that straightforward. 

Therefore I submitted this PR to see what it does, but I think we should hold that change and ask why format is the best term for the job. Types seems more adequate a priori (a type of identifier), but there's probably a reason why they chose format instead. Even if it's still a draft, we should also ask whether it's considered stable, since our syntax depends on it. Of course, if it changes later, a mapping is possible, but that's extra gruntwork for all parties (one of the value of using sub_ids is to make the mapping straighforward). 

Please let me know what you think. If agreed, I can reach out to the editors. 