### PR TITLE
Replace parameter "ts" by "iat" for jws and jwsd key proofing mechanisms.

### DIFF
--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -3378,8 +3378,8 @@ htm (string)
 htu (string)
 : The HTTP URI used for this request, including all path and query components.
 
-ts (integer)
-: A timestamp of the request in integer seconds
+iat (integer)
+: A timestamp at which the JWS object was created.
 
 at_hash (string)
 : When a request is bound to an access token, the access token hash value. Its value is the 
@@ -3471,8 +3471,8 @@ htm (string)
 htu (string)
 : The HTTP URI used for this request, including all path and query components.
 
-ts (integer)
-: A timestamp of the request in integer seconds
+iat (integer)
+: A timestamp at which the JWS object was created.
 
 at_hash (string)
 : When a request is bound to an access token, the access token hash value. Its value is the 
@@ -3541,7 +3541,7 @@ This example's JWS header decodes to:
   "kid": "KAgNpWbRyy9Mf2rikl498LThMrvkbZWHVSQOBC4VHU4",
   "htm": "POST",
   "htu": "https://server.example.com/tx",
-  "ts": 1603800783
+  "iat": 1603800783
 }
 ~~~
 

--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -51,6 +51,7 @@ normative:
     RFC7468:
     RFC7515:
     RFC7517:
+    RFC7519:
     RFC6749:
     RFC6750:
     RFC7797:
@@ -3378,8 +3379,8 @@ htm (string)
 htu (string)
 : The HTTP URI used for this request, including all path and query components.
 
-iat (integer)
-: A timestamp at which the JWS object was created.
+iat (number)
+: Time at which the JWS object was created. Its value is `NumericDate` as defined in Section 2 of {{RFC7519}}.
 
 at_hash (string)
 : When a request is bound to an access token, the access token hash value. Its value is the 
@@ -3471,8 +3472,8 @@ htm (string)
 htu (string)
 : The HTTP URI used for this request, including all path and query components.
 
-iat (integer)
-: A timestamp at which the JWS object was created.
+iat (number)
+: Time at which the JWS object was created. Its value is `NumericDate` as defined in Section 2 of {{RFC7519}}.
 
 at_hash (string)
 : When a request is bound to an access token, the access token hash value. Its value is the 


### PR DESCRIPTION
Suggested changes for https://github.com/ietf-wg-gnap/gnap-core-protocol/pull/202#issuecomment-808941552