### PR TITLE
JWK definition

### DIFF
--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -1891,8 +1891,7 @@ expires_in (integer)
 key (object / string)
 : OPTIONAL. The key that the token is bound to, if different from the
     client instance's presented key. The key MUST be an object or string in a format
-    described in {{key-format}}, describing a public key to which the
-    client instance can use the associated private key. The client instance MUST be able to
+    described in {{key-format}}. The client instance MUST be able to
     dereference or process the key information in order to be able
     to sign the request.
 

--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -3213,9 +3213,10 @@ proof (string)
     {{binding-keys}}. The `proof` field is REQUIRED.
 
 jwk (object)
-: Value of the public key as a JSON Web Key {{RFC7517}}. The object MUST
-            contain an "alg" field which is used to validate the signature.
-            The object MUST contain the "kid" field to identify the key.
+: The public key and its properties represented as a JSON Web Key {{RFC7517}}.
+    A JWK MUST contain the "alg" (Algorithm) and "kid" (Key ID) parameters. The `alg`
+    parameter MUST NOT be `none`.  The JWK x5c (X.509 Certificate Chain) parameter MAY
+    be used to provide X.509 representation of the provided public key.
 
 cert (string)
 : PEM serialized value of the certificate used to

--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -3215,7 +3215,7 @@ proof (string)
 jwk (object)
 : The public key and its properties represented as a JSON Web Key {{RFC7517}}.
     A JWK MUST contain the "alg" (Algorithm) and "kid" (Key ID) parameters.  The `alg`
-    parameter MUST NOT be `none`.  The JWK x5c (X.509 Certificate Chain) parameter MAY
+    parameter MUST NOT be `none`.  The "x5c" (X.509 Certificate Chain) parameter MAY
     be used to provide X.509 representation of the provided public key.
 
 cert (string)

--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -3214,7 +3214,7 @@ proof (string)
 
 jwk (object)
 : The public key and its properties represented as a JSON Web Key {{RFC7517}}.
-    A JWK MUST contain the "alg" (Algorithm) and "kid" (Key ID) parameters. The `alg`
+    A JWK MUST contain the "alg" (Algorithm) and "kid" (Key ID) parameters.  The `alg`
     parameter MUST NOT be `none`.  The JWK x5c (X.509 Certificate Chain) parameter MAY
     be used to provide X.509 representation of the provided public key.
 

--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -3214,9 +3214,9 @@ proof (string)
 
 jwk (object)
 : The public key and its properties represented as a JSON Web Key {{RFC7517}}.
-    A JWK MUST contain the "alg" (Algorithm) and "kid" (Key ID) parameters.  The `alg`
-    parameter MUST NOT be `none`.  The "x5c" (X.509 Certificate Chain) parameter MAY
-    be used to provide X.509 representation of the provided public key.
+    A JWK MUST contain the `alg` (Algorithm) and `kid` (Key ID) parameters. The `alg`
+    parameter MUST NOT be "none". The `x5c` (X.509 Certificate Chain) parameter MAY
+    be used to provide the X.509 representation of the provided public key.
 
 cert (string)
 : PEM serialized value of the certificate used to


### PR DESCRIPTION
Suggested changes after the discussion in https://github.com/ietf-wg-gnap/gnap-core-protocol/issues/222.

I believe GNAP may also require using the JWK thumbprint as a "kid" (Key ID) value as described in [RFC7638](https://tools.ietf.org/html/rfc7638) with the hashing algorithm agreed in advance, for example, SHA256. That will be a collision-resistant value and protection against misuse.