### PR TITLE
Fix the payload of the introspection request.

### DIFF
--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -4277,6 +4277,7 @@ Detached-JWS: ejy0...
 
 {
     "access_token": "OS9M2PMHKUR64TB8N6BW7OZB8CDFONP219RP1LT0",
+    "client": "7C7C4AZ9KHRS6X63AJAO"
 }
 ~~~
 


### PR DESCRIPTION
Otherwise, there isn't any way for the AS to identify which client makes the introspection request (or at least, there is no obvious way for me).