### PR TITLE
Continuation information was stored on the step (2) not (3)

### DIFF
--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -602,7 +602,7 @@ The client instance polls the AS while it is waiting for the RO to authorize the
 5. When the AS is done interacting with the RO, the AS 
     indicates to the RO that the request has been completed.
     
-6. Meanwhile, the client instance loads the continuation information stored at (3) and 
+6. Meanwhile, the client instance loads the continuation information stored at (2) and 
     [continues the request](#continue-request). The AS determines which
     ongoing access request is referenced here and checks its state.
     


### PR DESCRIPTION
Typo for section 1.4.3 Asynchronous Authorization, step 6: 
The continuation information was stored on step (2) not (3) as specified in the latest draft.