### PR TITLE
Extract RS-focused protocol elements

### DIFF
--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -4306,6 +4306,8 @@ sure that it has the permission to do so.
     - Changed "key_proofs" to "key_proofs_supported".
     - Changed "assertions" to "assertions_supported".
     - Updated discovery and field names for subject formats.
+    - Updated discovery and field names for subject types.
+    - Refactored the RS-centric components into a new document. 
 
 - -04
     - Updated terminology.


### PR DESCRIPTION
This change set extracts the resource-server-focused elements of GNAP to allow the core protocol to focus on the client-AS relationship while this new document
can focus on the RS-AS relationship.

Closes #114

- remove RS section for refactoring

RS section now at: https://github.com/ietf-wg-gnap/gnap-resource-servers