### PR TITLE
Interact example typo: nonce value must be provided using 'finish' 

### DIFF
--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -1721,7 +1721,7 @@ a [callback nonce](#response-interact-callback), and a [continuation response](#
 {
     "interact": {
         "redirect": "https://server.example.com/interact/4CF492MLVMSW9MKMXKHQ",
-        "push": "MBDOFXG4Y5CVJCX821LH"
+        "finish": "MBDOFXG4Y5CVJCX821LH"
     },
     "continue": {
         "access_token": {


### PR DESCRIPTION
§3 Grant Response contains an invalid example for the ``interact`` object.
Accordingly to §3.3.3, it must contain ``finish`` instead of ``push`` for providing nonce value.