### PR TITLE
Use opaque identifier instead of user handle

### DIFF
--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -77,7 +77,7 @@ normative:
         -
           ins: C. Mortimore
 
---- abstract
+​--- abstract
 
 GNAP defines a mechanism for delegating authorization to a
 piece of software, and conveying that delegation to the software. This
@@ -85,7 +85,7 @@ delegation can include access to a set of APIs as well as information
 passed directly to the software.
 
 
---- middle
+​--- middle
 
 # Introduction
 
@@ -167,7 +167,7 @@ on the role by the overall protocol.
 Legend
 
 + + + indicates interaction between a human and computer
------ indicates interaction between two pieces of software
+​----- indicates interaction between two pieces of software
 ~ ~ ~ indicates a potential equivalence or out-of-band communication between roles
 
 ~~~
@@ -333,7 +333,7 @@ an access token to call an RS.
 
 Legend
 + + + indicates a possible interaction with a human
------ indicates an interaction between protocol roles
+​----- indicates an interaction between protocol roles
 ~ ~ ~ indicates a potential equivalence or out-of-band
         communication between roles
 ~~~
@@ -1106,6 +1106,7 @@ separate access tokens, `token1` and `token2`.
         "flags": [ "bearer" ]
     }
 ]
+
 ~~~
 
 All approved access requests are returned in the
@@ -1268,10 +1269,14 @@ logo_uri (string)
 
 
 ~~~
+
+
     "display": {
         "name": "My Client Display Name",
         "uri": "https://example.net/client"
     }
+
+
 ~~~
 
 \[\[ [See issue #48](https://github.com/ietf-wg-gnap/gnap-core-protocol/issues/48) \]\]
@@ -1336,6 +1341,7 @@ assertions (object)
      "id_token": "eyj..."
    }
 }
+
 ~~~
 
 
@@ -2306,7 +2312,7 @@ opaque to the client instance.
 
 All dynamically generated handles are returned as fields in the
 root JSON object of the response. This specification defines the
-following dynamic handle returns, additional handles can be defined in
+following dynamic handle return, additional handles can be defined in
 [a registry TBD](#IANA).
 
 
@@ -2315,20 +2321,16 @@ instance_id (string)
             in the `client` object that the client instance can use in a future request, as
             described in {{request-instance}}.
 
-user (string)
-: A string value used to represent the current user, that can be provided to a future request, as described in
-            {{request-user-reference}}. When the end-user is the RO, the handle is equivalent to the opaque subject identifier.   
-
-This non-normative example shows two handles along side an issued access token.
+This non-normative example shows one handle along side an issued access token.
 
 ~~~
 {
-    "user": "XUT2MFM1XBIKJKSDU8QM",
     "instance_id": "7C7C4AZ9KHRS6X63AJAO",
     "access_token": {
         "value": "OS9M2PMHKUR64TB8N6BW7OZB8CDFONP219RP1LT0"
     }
 }
+
 ~~~
 
 \[\[ [See issue #77](https://github.com/ietf-wg-gnap/gnap-core-protocol/issues/77) \]\]
@@ -4520,7 +4522,7 @@ sure that it has the permission to do so.
 # Document History {#history}
 
 - Since -06
-    -
+    * Replace user handle by opaque identifier 
 
 - -06
     - Removed "capabilities" and "existing_grant" protocol fields.

--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -179,7 +179,7 @@ Client
 : application operated by an end-user that consumes resources from one or several RSs, possibly requiring access privileges from one or several ASs.
 
     Example: a client can be a mobile application, a web application, etc.
-
+    
     Note: this specification differentiates between a specific instance (the client instance, identified by its unique key) and the software running the instance (the client software). For some kinds of client software, there could be many instances of that software, each instance with a different key.
 
 Resource Server (RS)
@@ -1545,7 +1545,7 @@ method (string)
     "redirect"
     : Indicates that the client instance can receive a redirect from the end-user's device
     after interaction with the RO has concluded. {{request-interact-callback-redirect}}
-
+    
     "push"
     : Indicates that the client instance can receive an HTTP POST request from the AS
     after interaction with the RO has concluded. {{request-interact-callback-push}}
@@ -1703,15 +1703,11 @@ interact (object)
     needs to take place. {{response-interact}}
 
 subject (object)
-: Claims about the RO as known and declared by the AS. {{response-subject}}
+: Claims about the RO as known and declared by the AS, as described in {{response-subject}}. 
 
 instance_id (string)
 : An identifier this client instance can use to identify itself when making
     future requests. {{response-dynamic-handles}}
-
-user_handle (string)
-: An identifier this client instance can use to identify its current end-user when
-    making future requests. {{response-dynamic-handles}}
 
 error (object)
 : An error code indicating that something has gone wrong. {{response-error}}
@@ -1735,8 +1731,7 @@ a [callback nonce](#response-interact-finish), and a [continuation response](#re
 }
 ~~~
 
-In this example, the AS is returning a bearer [access token](#response-token-single)
-with a management URL and a [subject identifier](#response-subject) in the form of
+In this example, the AS is returning a bearer [access token](#response-token-single) with a management URL and a [subject identifier](#response-subject) in the form of
 an opaque identifier.
 
 ~~~
@@ -2229,12 +2224,15 @@ mode responses in [a registry TBD](#IANA). Extensions MUST
 document the corresponding interaction request.
 
 
-## Returning User Information {#response-subject}
+## Returning Subject Information {#response-subject}
 
 If information about the RO is requested and the AS
 grants the client instance access to that data, the AS returns the approved
-information in the "subject" response field. This field is an object
-with the following OPTIONAL properties.
+information in the "subject" response field. The AS MUST return the `subject` field only in cases where the AS is sure that
+the RO and the end-user are the same party. This can be accomplished through some forms of
+[interaction with the RO](#authorization).
+
+This field is an object with the following OPTIONAL properties.
 
 
 sub_ids (array of objects)
@@ -2259,17 +2257,13 @@ updated_at (string)
 "subject": {
    "sub_ids": [ {
      "format": "opaque",
-     "id": "J2G8G8O4AZ"
+     "id": "XUT2MFM1XBIKJKSDU8QM"
    } ],
    "assertions": {
      "id_token": "eyj..."
    }
 }
 ~~~
-
-The AS MUST return the `subject` field only in cases where the AS is sure that
-the RO and the end-user are the same party. This can be accomplished through some forms of
-[interaction with the RO](#authorization).
 
 Subject identifiers returned by the AS SHOULD uniquely identify the RO at the
 AS. Some forms of subject identifier are opaque to the client instance (such as the subject of an
@@ -2321,18 +2315,15 @@ instance_id (string)
             in the `client` object that the client instance can use in a future request, as
             described in {{request-instance}}.
 
-user_handle (string)
-: A string value used to represent the current
-            user. The client instance can use in a future request, as described in
-            {{request-user-reference}}.
+user (string)
+: A string value used to represent the current user, that can be provided to a future request, as described in
+            {{request-user-reference}}. When the end-user is the RO, the handle is equivalent to the opaque subject identifier.   
 
-
-This non-normative example shows two handles along side an issued
-access token.
+This non-normative example shows two handles along side an issued access token.
 
 ~~~
 {
-    "user_handle": "XUT2MFM1XBIKJKSDU8QM",
+    "user": "XUT2MFM1XBIKJKSDU8QM",
     "instance_id": "7C7C4AZ9KHRS6X63AJAO",
     "access_token": {
         "value": "OS9M2PMHKUR64TB8N6BW7OZB8CDFONP219RP1LT0"

--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -77,7 +77,7 @@ normative:
         -
           ins: C. Mortimore
 
-​--- abstract
+--- abstract
 
 GNAP defines a mechanism for delegating authorization to a
 piece of software, and conveying that delegation to the software. This
@@ -85,7 +85,7 @@ delegation can include access to a set of APIs as well as information
 passed directly to the software.
 
 
-​--- middle
+--- middle
 
 # Introduction
 
@@ -167,7 +167,7 @@ on the role by the overall protocol.
 Legend
 
 + + + indicates interaction between a human and computer
-​----- indicates interaction between two pieces of software
+----- indicates interaction between two pieces of software
 ~ ~ ~ indicates a potential equivalence or out-of-band communication between roles
 
 ~~~
@@ -333,7 +333,7 @@ an access token to call an RS.
 
 Legend
 + + + indicates a possible interaction with a human
-​----- indicates an interaction between protocol roles
+----- indicates an interaction between protocol roles
 ~ ~ ~ indicates a potential equivalence or out-of-band
         communication between roles
 ~~~


### PR DESCRIPTION
Opaque identifiers provide a generic reference, so we can simplify the text. 

Closes #302 (mainly), and as a byproduct also closes #197 and closes #51
- removed user_handle from main response in section 3
- changed title of section 3.4 (User -> Subject) and moved the text that requires RO = end-user at the top of the section, for clarity
- changed name (user_handle -> user) and wording in section 3.5. Maybe we could also simplify the title "Returning Dynamically-bound Reference Handles" into "Returning Reference Handles" (didn't do it yet).