### PR TITLE
Remove 'bearer'

### DIFF
--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -5455,7 +5455,7 @@ Digest: sha256=...
 
 
 The AS retrieves the pending request based on the handle and issues
-a bearer access token and returns this to the client instance.
+an access token and returns this to the client instance.
 
 ~~~
 NOTE: '\' line wrapping per RFC 8792


### PR DESCRIPTION
The bearer flag is not used in the client instance's initial request nor in the AS's response. The access token should therefore be bound to the client instance's key used in the request.