### PR TITLE
Collapse user code into string

### DIFF
--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -2192,7 +2192,7 @@ interaction methods are included in the same `interact` object.
 `app` (string):
 : Launch of an application URI. REQUIRED if the `app` interaction start mode is possible for this request. See {{response-interact-app}}.
 
-`user_code` (object):
+`user_code` (string):
 : Display a short user code. REQUIRED if the `user_code` interaction start mode is possible for this request. See {{response-interact-usercode}}.
 
 `user_code_uri` (object):
@@ -2272,29 +2272,23 @@ application URI. See details of the interaction in {{interaction-app}}.
 If the client instance indicates that it can
 [display a short user-typeable code](#request-interact-usercode)
 and the AS supports this mode for the client instance's
-request, the AS responds with a "user_code" field. This field is an
-object that contains the following members.
-
-
-`code` (string):
-: A unique short code that the user
-    can type into a web page. This string MUST be
-    case-insensitive, MUST consist of only easily typeable
-    characters (such as letters or numbers). The time in which this
-    code will be accepted SHOULD be short lived, such as several
-    minutes. It is RECOMMENDED that this code be no more than eight
-    characters in length.
-    REQUIRED.
+request, the AS responds with a "user_code" field. This field is string
+containing a unique short code that the user
+can type into a web page. This string MUST be
+case-insensitive, MUST consist of only easily typeable
+characters (such as letters or numbers). The time in which this
+code will be accepted SHOULD be short lived, such as several
+minutes. It is RECOMMENDED that this code be no more than eight
+characters in length.
+REQUIRED.
 
 ~~~
 "interact": {
-    "user_code": {
-        "code": "A1BC-3DFF",
-    }
+    "user_code": "A1BC-3DFF"
 }
 ~~~
 
-The client instance MUST communicate the "code" to the end user in some
+The client instance MUST communicate the "user_code" value to the end user in some
 fashion, such as displaying it on a screen or reading it out
 audibly. This code is used by the interaction component of the AS as a means
 of identifying the pending grant request and does not function as an
@@ -5742,6 +5736,7 @@ Throughout many parts of GNAP, the parties pass shared references between each o
 
 - -10
     -
+    - Collapse "user_code" into a string instead of an object.
 
 - -09
     - Added security considerations on redirection status codes.


### PR DESCRIPTION
Instead of using an object with a single member, the `user_code` interaction start method now uses a simple string, in line with the `redirect` and `app` methods.﻿
