### PR TITLE
update error response as an object or as a string

### DIFF
--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -2316,7 +2316,7 @@ If the AS determines that the request cannot be issued for any reason, it respon
 
     `"invalid_code"`
     : The code provided by the user is refused.
-    
+
     `"invalid_continuation"`:
     : The continuation of the referenced grant could not be processed.
 
@@ -2328,7 +2328,7 @@ If the AS determines that the request cannot be issued for any reason, it respon
 
     `"unknown_interaction"`:
     : The interaction integrity could not be established.
-    
+
     `"too_fast"`:
     : The client instance did not respect the timeout in the wait response.
 

--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -1234,7 +1234,7 @@ RO and MUST NOT be taken as declarative statements that a particular
 RO is present at the client instance and acting as the end user. Assertions SHOULD be validated by the AS.
 
 If the identified end user does not match the RO present at the AS
-during an interaction step, the AS SHOULD reject the request with an "user_denied" error.
+during an interaction step, the AS SHOULD reject the request with an "unknown_user" error.
 
 If the AS trusts the client instance to present verifiable assertions, the AS MAY
 decide, based on its policy, to skip interaction with the RO, even
@@ -1267,7 +1267,7 @@ user identifiers or structured assertions. For the client instance to send
 either of these, use the full [user request object](#request-user) instead.
 
 If the AS does not recognize the user reference, it MUST
-return a "user_denied" error.
+return an "unknown_user" error.
 
 ## Interacting with the User {#request-interact}
 
@@ -2326,6 +2326,9 @@ If the AS determines that the request cannot be issued for any reason, it respon
     `"request_denied"`:
     : The request was denied for an unspecified reason.
 
+    `"unknown_user"`:
+    : The user presented in the request is not known to the AS or does not match the user present during interaction.
+
     `"unknown_interaction"`:
     : The interaction integrity could not be established.
 
@@ -2354,6 +2357,7 @@ continue the grant request:
 ~~~
 
 Alternatively, the AS MAY choose to only return the error as codes and provide a error as a string. The following response is considered equivalent to the previous example :
+
 ~~~ json
 {
     "error": "user_denied"
@@ -2485,7 +2489,7 @@ In many cases, the URI indicates a web page hosted at the AS, allowing the
 AS to authenticate the end user as the RO and interactively provide consent.
 The URI value is used to identify the grant request being authorized.
 If the URI cannot be associated with a currently active
-request, the AS MUST display an "invalid_interaction" error to the RO and MUST NOT attempt
+request, the AS MUST display an error to the RO and MUST NOT attempt
 to redirect the RO back to any client instance even if a [redirect finish method is supplied](#request-interact-callback-redirect).
 If the URI is not hosted by the AS directly, the means of communication between
 the AS and this URI are out of scope for this specification.
@@ -2514,7 +2518,7 @@ In many cases, the URI indicates a web page hosted at the AS, allowing the
 AS to authenticate the end user as the RO and interactively provide consent.
 The value of the user code is used to identify the grant request being authorized.
 If the user code cannot be associated with a currently active
-request, the AS MUST display an "invalid_code" error to the RO and MUST NOT attempt
+request, the AS MUST display an error to the RO and MUST NOT attempt
 to redirect the RO back to any client instance even if a [redirect finish method is supplied](#request-interact-callback-redirect).
 If the interaction component at the user code URI is not hosted by the AS directly, the means of communication between
 the AS and this URI, including communication of the user code itself, are out of scope for this specification.
@@ -2522,8 +2526,8 @@ the AS and this URI, including communication of the user code itself, are out of
 When the RO enters this code at the user code URI,
 the AS MUST uniquely identify the pending request that the code was associated
 with. If the AS does not recognize the entered code, the interaction component MUST
-display an "invalid_code" error to the user. If the AS detects too many unrecognized code
-enter attempts, the interaction component SHOULD display an "too_many_attempts" error to the user and
+display an error to the user. If the AS detects too many unrecognized code
+enter attempts, the interaction component SHOULD display an error to the user indicating too many attempts and
 MAY take additional actions such as slowing down the input interactions.
 The user should be warned as such an error state is approached, if possible.
 
@@ -2546,7 +2550,7 @@ In many cases, the URI indicates a web page hosted at the AS, allowing the
 AS to authenticate the end user as the RO and interactively provide consent.
 The value of the user code is used to identify the grant request being authorized.
 If the user code cannot be associated with a currently active
-request, the AS MUST display an "invalid_code" error to the RO and MUST NOT attempt
+request, the AS MUST display an error to the RO and MUST NOT attempt
 to redirect the RO back to any client instance even if a [redirect finish method is supplied](#request-interact-callback-redirect).
 If the interaction component at the user code URI is not hosted by the AS directly, the means of communication between
 the AS and this URI, including communication of the user code itself, are out of scope for this specification.
@@ -2554,8 +2558,8 @@ the AS and this URI, including communication of the user code itself, are out of
 When the RO enters this code at the given URI,
 the AS MUST uniquely identify the pending request that the code was associated
 with. If the AS does not recognize the entered code, the interaction component MUST
-display an "invalid_code" error to the user. If the AS detects too many unrecognized code
-enter attempts, the interaction component SHOULD display an "too_many_attempts" error to the user and
+display an error to the user. If the AS detects too many unrecognized code
+enter attempts, the interaction component SHOULD display an error to the user indicating too many attempts and
 MAY take additional actions such as slowing down the input interactions.
 The user should be warned as such an error state is approached, if possible.
 

--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -2333,10 +2333,10 @@ continue the grant request:
 
 ~~~ json
 {
-  "error": {
-      "code": "user_denied",
-      "description": "The RO denied the request"
-  }
+    "error": {
+        "code": "user_denied",
+        "description": "The RO denied the request"
+    },
 }
 ~~~
 

--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -2338,6 +2338,13 @@ continue the grant request:
 }
 ~~~
 
+Alternatively, the AS MAY choose to only return the error as codes and provide a error as a string. The following response is considered equivalent to the previous example : 
+~~~ json
+{
+    "error": "user_denied"
+}
+~~~
+
 # Determining Authorization and Consent {#authorization}
 
 When the client instance makes its [initial request](#request) to the AS for delegated access, it
@@ -6306,6 +6313,7 @@ Throughout many parts of GNAP, the parties pass shared references between each o
 # Document History {#history}
 
 - -11
+    - Error as object or string, more complete set of error codes
     - Added key rotation in token management.
     - Restrict keys to a single format per message.
     - Discussed security issues of multiple key formats.

--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -3378,7 +3378,7 @@ Content-Digest: sha-256=...
 }
 ~~~
 
-An attempt to change the `proof` method or parameters, including an attempt to rotate the key of a bearer token (which has no key), MUST result in a "request_denied" error code returned from the AS.
+An attempt to change the `proof` method or parameters, including an attempt to rotate the key of a bearer token (which has no key), MUST result in a "invalid_rotation" error code returned from the AS.
 
 ## Revoking the Access Token {#revoke-access-token}
 
@@ -5229,6 +5229,7 @@ Specification document(s):
 |too_fast|{{response-error}} of {{&SELF}}|
 |unknown_request|{{response-error}} of {{&SELF}}|
 |request_denied|{{response-error}} of {{&SELF}}|
+|invalid_rotation|{{response-error}} of {{&SELF}}|
 |invalid_interaction|{{response-error}} of {{&SELF}}|
 
 ## Key Proofing Methods {#IANA-key-proof-methods}

--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -2290,9 +2290,12 @@ If the AS determines that the request cannot be issued for any
 reason, it responds to the client instance with an error message.
 
 
-`error` (string):
+`error` (object):
+:   An error contains a "code" and, optionally, its associated "description"
+
+`code` (string):
 :   A single ASCII error code from the
-    following, with additional values available in the [Error Response Registry](#IANA-error-response).
+    following, with additional values available in the [Error Code Registry](#IANA-error-code).
     REQUIRED.
 
     `"invalid_request"`:
@@ -2319,7 +2322,7 @@ reason, it responds to the client instance with an error message.
     : The client instance has provided an interaction reference that is incorrect
         for this request or the interaction modes in use have expired.
 
-`error_description` (string):
+`description` (string):
 :   A human-readable string description of the error intended for the
     developer of the client.
     OPTIONAL.
@@ -2330,7 +2333,10 @@ continue the grant request:
 
 ~~~ json
 {
-  "error": "user_denied"
+  "error": {
+      "code": "user_denied",
+      "description": "The RO denied the request"
+  }
 }
 ~~~
 
@@ -3374,7 +3380,7 @@ Content-Digest: sha-256=...
 }
 ~~~
 
-An attempt to change the `proof` method or parameters, including an attempt to rotate the key of a bearer token (which has no key), MUST result in an error returned from the AS.
+An attempt to change the `proof` method or parameters, including an attempt to rotate the key ofError Response a bearer token (which has no key), MUST result in a "request_denied" error returned from the AS.
 
 ## Revoking the Access Token {#revoke-access-token}
 
@@ -5200,11 +5206,11 @@ Specification document(s):
 |assertions|array of objects|{{response-subject}} of {{&SELF}}|
 |updated_at|string|{{response-subject}} of {{&SELF}}|
 
-## Error Responses {#IANA-error-response}
+## Error Codes {#IANA-error-code}
 
-This document defines a set of errors that the AS can return to the client instance, for which IANA is asked to create and maintain a new registry titled "Error Responses". Initial values for this registry are given in {{IANA-error-response-contents}}. Future assignments and modifications to existing assignment are to be made through the Expert Review registration policy {{?RFC8126}} and shall follow the template presented in {{IANA-error-response-template}}.
+This document defines a set of errors that the AS can return to the client instance, for which IANA is asked to create and maintain a new registry titled "Error Codes". Initial values for this registry are given in {{IANA-error-code-contents}}. Future assignments and modifications to existing assignment are to be made through the Expert Review registration policy {{?RFC8126}} and shall follow the template presented in {{IANA-error-response-template}}.
 
-### Registration Template {#IANA-error-response-template}
+### Registration Template {#IANA-error-code-template}
 
 {: vspace="0"}
 Error:

--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -2316,6 +2316,9 @@ If the AS determines that the request cannot be issued for any reason, it respon
 
     `"invalid_code"`
     : The code provided by the user is refused.
+    
+    `"invalid_continuation"`:
+    : The continuation of the referenced grant could not be processed.
 
     `"user_denied"`:
     : The RO denied the request.
@@ -2325,7 +2328,7 @@ If the AS determines that the request cannot be issued for any reason, it respon
 
     `"unknown_interaction"`:
     : The interaction integrity could not be established.
-
+    
     `"too_fast"`:
     : The client instance did not respect the timeout in the wait response.
 
@@ -5251,6 +5254,7 @@ Specification document(s):
 |user_denied|{{response-error}} of {{&SELF}}|
 |request_denied|{{response-error}} of {{&SELF}}|
 |unknown_interaction|{{response-error}} of {{&SELF}}|
+|unknown_grant|{{response-error}} of {{&SELF}}|
 |too_fast|{{response-error}} of {{&SELF}}|
 |too_many_attempts|{{response-error}} of {{&SELF}}|
 

--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -5206,7 +5206,7 @@ Specification document(s):
 
 ## Error Codes {#IANA-error-code}
 
-This document defines a set of errors that the AS can return to the client instance, for which IANA is asked to create and maintain a new registry titled "Error Codes". Initial values for this registry are given in {{IANA-error-code-contents}}. Future assignments and modifications to existing assignment are to be made through the Expert Review registration policy {{?RFC8126}} and shall follow the template presented in {{IANA-error-response-template}}.
+This document defines a set of errors that the AS can return to the client instance, for which IANA is asked to create and maintain a new registry titled "Error Codes". Initial values for this registry are given in {{IANA-error-code-contents}}. Future assignments and modifications to existing assignment are to be made through the Expert Review registration policy {{?RFC8126}} and shall follow the template presented in {{IANA-error-code-template}}.
 
 ### Registration Template {#IANA-error-code-template}
 
@@ -5220,7 +5220,7 @@ Specification document(s):
     to retrieve a copy of the document(s). An indication of the
     relevant sections may also be included but is not required.
 
-### Initial Contents {#IANA-error-response-contents}
+### Initial Contents {#IANA-error-code-contents}
 
 |Error|Specification document(s)|
 |invalid_request|{{response-error}} of {{&SELF}}|

--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -2286,12 +2286,10 @@ This non-normative example shows an instance identifier along side an issued acc
 
 ## Error Response {#response-error}
 
-If the AS determines that the request cannot be issued for any
-reason, it responds to the client instance with an error message.
-
+If the AS determines that the request cannot be issued for any reason, it responds to the client instance with an "error" response.
 
 `error` (object):
-:   An error contains a "code" and, optionally, its associated "description"
+: An error contains an error "code" and, optionally, its associated error "description"
 
 `code` (string):
 :   A single ASCII error code from the
@@ -2336,7 +2334,7 @@ continue the grant request:
     "error": {
         "code": "user_denied",
         "description": "The RO denied the request"
-    },
+    }
 }
 ~~~
 

--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -5251,10 +5251,10 @@ Specification document(s):
 |invalid_code|{{response-error}} of {{&SELF}}|
 |invalid_flag|{{response-error}} of {{&SELF}}|
 |invalid_rotation|{{response-error}} of {{&SELF}}|
+|invalid_continuation|{{response-error}} of {{&SELF}}|
 |user_denied|{{response-error}} of {{&SELF}}|
 |request_denied|{{response-error}} of {{&SELF}}|
 |unknown_interaction|{{response-error}} of {{&SELF}}|
-|unknown_grant|{{response-error}} of {{&SELF}}|
 |too_fast|{{response-error}} of {{&SELF}}|
 |too_many_attempts|{{response-error}} of {{&SELF}}|
 

--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -3380,7 +3380,7 @@ Content-Digest: sha-256=...
 }
 ~~~
 
-An attempt to change the `proof` method or parameters, including an attempt to rotate the key ofError Response a bearer token (which has no key), MUST result in a "request_denied" error returned from the AS.
+An attempt to change the `proof` method or parameters, including an attempt to rotate the key of a bearer token (which has no key), MUST result in a "request_denied" error code returned from the AS.
 
 ## Revoking the Access Token {#revoke-access-token}
 

--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -2338,7 +2338,7 @@ continue the grant request:
 }
 ~~~
 
-Alternatively, the AS MAY choose to only return the error as codes and provide a error as a string. The following response is considered equivalent to the previous example : 
+Alternatively, the AS MAY choose to only return the error as codes and provide a error as a string. The following response is considered equivalent to the previous example :
 ~~~ json
 {
     "error": "user_denied"


### PR DESCRIPTION
Closes #79 

This issue also checks all errors : 
- in section 1 : when referring to errors, it is a generic term / no change needed
- same in the security considerations
- elsewhere we aim to have specific errors