### PR TITLE
refactor object-style proof formats

### DIFF
--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -1335,12 +1335,14 @@ request without authorization.
 
 ### Start Mode Definitions {#request-interact-start}
 
-Interaction start modes are specified by a string, which consists of the start mode on its own, or by a JSON object with one required field and any number of optional parameters defined by the mode:
+Interaction start modes are specified by a string, which consists of the start mode name on its
+own, or by a JSON object with one required field and any number of parameters defined by
+the mode.
 
 `mode`:
-: The interaction start mode.
+: The interaction start mode. REQUIRED.
 
-Individual modes MAY define additional parameters to be required in the object.
+Individual modes defined as objects MAY define additional parameters to be required in the object.
 
 This specification defines the following interaction start modes:
 
@@ -3585,61 +3587,57 @@ and the `key` field is present with any value.
 
 Any keys presented by the client instance to the AS or RS MUST be validated as
 part of the request in which they are presented. The type of binding
-used is indicated by the `proof` parameter of the key object in {{key-format}}. This
-parameter is formally specified by an object with at least the following member:
+used is indicated by the `proof` parameter of the key object in {{key-format}}.
+Key proof methods are specified either by a string, which consists of the key proof
+method name on its own, or by a JSON object with one required field and any number of optional
+parameters defined by the method:
 
 `method`:
 : The name of the key proofing method to be used.
     REQUIRED.
 
-Individual methods MAY define additional parameters as members in this object.
+Individual methods defined as objects MAY define additional parameters as members in this object.
 
 Values for the `method` defined by this specification are as follows:
 
-`"httpsig"`:
+`"httpsig"` (string or object):
 : HTTP Signing signature headers. See {{httpsig-binding}}.
 
-`"mtls"`:
+`"mtls"` (string):
 : Mutual TLS certificate verification. See {{mtls}}.
 
-`"jwsd"`:
+`"jwsd"` (string):
 : A detached JWS signature header. See {{detached-jws}}.
 
-`"jws"`:
+`"jws"` (string):
 : Attached JWS payload. See {{attached-jws}}.
 
 Additional proofing methods are defined by the [Key Proofing Methods Registry](#IANA-key-proof-methods).
 
-For example, the `httpsig` method can be specified with its parameters as:
+In cases where a method's parameters can be set to omitted or set to default values, methods MAY be
+defined as both an object and a string. For example, the `httpsig` method can be specified as an
+object with its parameters explicitly declared, such as:
 
 ~~~ json
 {
     "proof": {
         "method": "httpsig",
-        "alg": "rsa-pss-sha512",
-        "content-digest-alg": "sha512"
+        "alg": "ecdsa-p384-sha384",
+        "content-digest-alg": "sha-256"
     }
 }
 ~~~
 
-If additional parameters are not required or used for a specific method, the method MAY be passed
-as a string instead of an object. For example, the `mtls` method with no additional parameters could be sent by the client instance as:
+The `httpsig` method also defines defines default behavior when it is passed as a string form:
 
 ~~~ json
 {
-    "proof": "mtls"
+    "proof": "httpsig"
 }
 ~~~
 
-The AS would map this to the equivalent expanded form as follows:
-
-~~~ json
-{
-    "proof": {
-        "method": "mtls"
-    }
-}
-~~~
+This is explicitly defined as the signature algorithm  specified by the associated key
+material and the content digest is calculated using sha-512.
 
 All key binding methods used by this specification MUST cover all relevant portions
 of the request, including anything that would change the nature of the request, to allow
@@ -3716,19 +3714,43 @@ NOTE: '\' line wrapping per RFC 8792
 
 ### HTTP Message Signatures {#httpsig-binding}
 
-This method is indicated by the method value `httpsig`. The signer creates an HTTP
-Message Signature as described in {{I-D.ietf-httpbis-message-signatures}}. This method defines the following parameters:
+This method is indicated by the method value `httpsig` and can be declared in either object
+form or string form.
+
+When the proof method is specified in object form, the following parameters are defined:
 
 `alg`:
-: The explicit HTTP signature algorithm, from the HTTP Signature Algorithm registry. If
-    this parameter is omitted, the signing algorithm MUST be derived from the key
-    material (such as using the JWS algorithm in a JWK formatted key). OPTIONAL.
+: The HTTP signature algorithm, from the HTTP Signature Algorithm registry. REQUIRED.
 
 `content-digest-alg`:
-: The algorithm used for the Content-Digest field, used to protect the body. If this
-    parameter is omitted, its value is `sha-256`. OPTIONAL.
+: The algorithm used for the Content-Digest field, used to protect the body. REQUIRED.
 
-The covered components of the signature MUST include the following:
+This example uses the ECDSA signing algorithm over the P384 curve and the SHA-256 hashing
+algorithm for the content digest.
+
+~~~ json
+{
+    "proof": {
+        "method": "httpsig",
+        "alg": "ecdsa-p384-sha384",
+        "content-digest-alg": "sha-256"
+    }
+}
+~~~
+
+When the proof method is specified in string form, the signing algorithm MUST be derived from the
+key material (such as using the JWS algorithm in a JWK formatted key), and the content digest
+algorithm MUST be `sha-512`.
+
+~~~ json
+{
+    "proof": "httpsig"
+}
+~~~
+
+When using this method, the signer creates an HTTP Message Signature as described in
+{{I-D.ietf-httpbis-message-signatures}}. The covered components of the signature MUST include the
+following:
 
 `"@method"`:
 : The method used in the HTTP request.
@@ -3976,9 +3998,15 @@ The verifier MUST validate both signatures before processing the request for key
 
 ### Mutual TLS {#mtls}
 
-This method is indicated by the method value `mtls`. This method defines no
-additional parameters. The signer presents its TLS client
-certificate during TLS negotiation with the verifier.
+This method is indicated by the method value `mtls` in string form.
+
+~~~ json
+{
+    "proof": "mtls"
+}
+~~~
+
+The signer presents its TLS client certificate during TLS negotiation with the verifier.
 
 In this example, the certificate is communicated to the application
 through the `Client-Cert` header from a TLS reverse proxy, leading
@@ -4074,8 +4102,15 @@ deployment practices, as discussed in {{security-mtls-patterns}}.
 
 ### Detached JWS {#detached-jws}
 
-This method is indicated by the method value `jwsd`. This method defines no
-additional parameters. A JWS {{RFC7515}} object is created as follows:
+This method is indicated by the method value `jwsd` in string form.
+
+~~~ json
+{
+    "proof": "jwsd"
+}
+~~~
+
+The signer creates a JWS {{RFC7515}} object as follows:
 
 To protect the request, the JOSE header of the signature contains the following
 claims:
@@ -4260,8 +4295,15 @@ object, to be signed by the new key.
 
 ### Attached JWS {#attached-jws}
 
-This method is indicated by the method value `jws`. This method defines no
-additional parameters. A JWS {{RFC7515}} object is created as follows:
+This method is indicated by the method value `jws` in string form.
+
+~~~ json
+{
+    "proof": "jws"
+}
+~~~
+
+The signer creates a JWS {{RFC7515}} object as follows:
 
 To protect the request, the JWS header contains the following claims.
 
@@ -5237,6 +5279,9 @@ This document defines methods that the client instance can use to prove possessi
 Method:
 : A unique string code for the key proofing method.
 
+Type:
+: The JSON type allowed for the value.
+
 Specification document(s):
 : Reference to the document(s) that specify the
     value, preferably including a URI that can be used
@@ -5245,11 +5290,12 @@ Specification document(s):
 
 ### Initial Contents {#IANA-key-proof-methods-contents}
 
-|Method|Specification document(s)|
-|httpsig|{{httpsig-binding}} of {{&SELF}}|
-|mtls|{{mtls}} of {{&SELF}}|
-|jwsd|{{detached-jws}} of {{&SELF}}|
-|jws|{{attached-jws}} of {{&SELF}}|
+|Method|Type|Specification document(s)|
+|httpsig|string|{{httpsig-binding}} of {{&SELF}}|
+|httpsig|object|{{httpsig-binding}} of {{&SELF}}|
+|mtls|string|{{mtls}} of {{&SELF}}|
+|jwsd|string|{{detached-jws}} of {{&SELF}}|
+|jws|string|{{attached-jws}} of {{&SELF}}|
 
 ## Key Formats {#IANA-key-formats}
 
@@ -7090,11 +7136,18 @@ within GNAP allows extensions to define new fields by not only choosing a new na
 using an existing name with a new type. However, the extension's definition
 of a new type for a field needs to fit the same kind of item being extended. For example, a
 hypothetical extension could define a string value for the `access_token` request field,
-with a URL to download an access token request. Such an extension would be appropriate as
+with a URL to download a hosted access token request. Such an extension would be appropriate as
 the `access_token` field still defines the access tokens being requested. However, if an extension
 were to define a string value for the `access_token` request field, with the value instead
 being something unrelated to the access token request such as a value or key format, this would
-not be an appropriate means of extension.
+not be an appropriate means of extension. (Note that this specific extension example would create
+another form of SSRF attack surface as discussed in {{security-ssrf}}.)
+
+For another example, both interaction [interaction start modes](#request-interact-start) and
+[key proofing methods](#binding-keys) can be defined as either strings or objects. An extension
+could take a method defined as a string, such as `app`, and define an object-based version with
+additional parameters. This extension should still define a method to launch an application on the
+end user's device, just like `app` does when specified as a string.
 
 Additionally, the ability to deal with different types for a field is not expected to be equal
 between an AS and client software, with the client software being assumed to be both more varied


### PR DESCRIPTION
This reformats the object-type key proofs to be defined in terms of types, in parallel with interaction start methods. Now instead of default field values, you can have 
either an object with parameters or a string with strictly specified behavior. This should be less susceptible to confusion than the previous definition which allowed 
partial objects and implied a large set of possible combinations that the receiver would have to deal with.
