### PR TITLE
Clarify CI validation of interaction pushback

### DIFF
--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -2869,7 +2869,7 @@ When processing such a call, the AS MUST protect itself against SSRF attacks as 
 
 When receiving the request, the client instance MUST parse the JSON object
 and validate the hash value as described in
-{{interaction-hash}}, or else return an `unknown_interaction` error ({{response-error}}). If the hash validates, the client instance sends
+{{interaction-hash}}. If either fails, the client instance MUST return an `unknown_interaction` error ({{response-error}}). If the hash validates, the client instance sends
 a continuation request to the AS as described in {{continue-after-interaction}} using the interaction
 reference value received here.
 


### PR DESCRIPTION
The current formulation regarding the client instance's validation of a pushed interaction completion notification can be misunderstood as "client instance must either parse JSON & verify hash or return an error", whereas I think the intended meaning is "client instance must parse JSON and verify hash. If either fails, return an error."