### PR TITLE
Nit: multiple components, but client instance not plural

### DIFF
--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -283,7 +283,7 @@ that run separately but all share the same key material, such as a
 deployed cluster, then this cluster is considered a single client instance.
 In these cases, the distinct components of what is considered a GNAP client instance
 may use any number of different communication mechanisms between them, all of which
-would be considered an implementation detail of the client instances and out of scope of GNAP.
+would be considered an implementation detail of the client instance and out of scope of GNAP.
 
 For another example, an AS could likewise be built out of many constituent
 components in a distributed architecture. The component that the client instance


### PR DESCRIPTION
This sentence is about one client instance (not plural) consisting of several components that communicate between them.

Although writing 'client instances' (plural) here is not incorrect, is also doesn't seem necessary, and it feels a bit confusing, possibly suggesting that communication between client instances would also take place.