### PR TITLE
Give context to JSON block of request continuation response

### DIFF
--- a/draft-ietf-gnap-core-protocol.md
+++ b/draft-ietf-gnap-core-protocol.md
@@ -1935,6 +1935,8 @@ contains a JSON object with the following properties.
     The client instance MUST present the continuation access token in all requests to the continuation URI as described in {{use-access-token}}.
     REQUIRED.
 
+The following is a non-normative example.
+
 ~~~ json
 {
     "continue": {


### PR DESCRIPTION
Most other examples are preceded by a short sentence that say "In the following non-normative example, ...", but it seems for this one that introductory sentence is missing.